### PR TITLE
Add block body and header

### DIFF
--- a/data/transaction.go
+++ b/data/transaction.go
@@ -41,8 +41,10 @@ type Event struct {
 
 // BlockEvents holds events data for a block
 type BlockEvents struct {
-	Hash   string  `json:"hash"`
-	Events []Event `json:"events"`
+	Hash      string  `json:"hash"`
+	ShardID   uint32  `json:"shardId"`
+	TimeStamp uint64  `json:"timestamp"`
+	Events    []Event `json:"events"`
 }
 
 // RevertBlock holds revert event data
@@ -78,6 +80,16 @@ type SaveBlockData struct {
 	Txs       map[string]transaction.Transaction                 `json:"txs"`
 	Scrs      map[string]smartContractResult.SmartContractResult `json:"scrs"`
 	LogEvents []Event                                            `json:"events"`
+}
+
+// InterceptorBlockData holds the block data needed for processing
+type InterceptorBlockData struct {
+	Hash      string
+	Body      *block.Body
+	Header    *block.HeaderV2
+	Txs       map[string]transaction.Transaction
+	Scrs      map[string]smartContractResult.SmartContractResult
+	LogEvents []Event
 }
 
 // ArgsSaveBlockData will contain all information that are needed to save block data

--- a/facade/interface.go
+++ b/facade/interface.go
@@ -39,6 +39,6 @@ type Publisher interface {
 
 // EventsInterceptor defines the behaviour of an events interceptor component
 type EventsInterceptor interface {
-	ProcessBlockEvents(eventsData *data.ArgsSaveBlockData) (*data.SaveBlockData, error)
+	ProcessBlockEvents(eventsData *data.ArgsSaveBlockData) (*data.InterceptorBlockData, error)
 	IsInterfaceNil() bool
 }

--- a/facade/notifierFacade.go
+++ b/facade/notifierFacade.go
@@ -65,8 +65,10 @@ func (nf *notifierFacade) HandlePushEventsV2(allEvents data.ArgsSaveBlockData) e
 	}
 
 	pushEvents := data.BlockEvents{
-		Hash:   eventsData.Hash,
-		Events: eventsData.LogEvents,
+		Hash:      eventsData.Hash,
+		ShardID:   eventsData.Header.GetShardID(),
+		TimeStamp: eventsData.Header.GetTimeStamp(),
+		Events:    eventsData.LogEvents,
 	}
 	err = nf.eventsHandler.HandlePushEvents(pushEvents)
 	if err != nil {

--- a/facade/notifierFacade_test.go
+++ b/facade/notifierFacade_test.go
@@ -82,7 +82,7 @@ func TestHandlePushEvents(t *testing.T) {
 
 		expectedErr := errors.New("expected error")
 		args.EventsInterceptor = &mocks.EventsInterceptorStub{
-			ProcessBlockEventsCalled: func(eventsData *data.ArgsSaveBlockData) (*data.SaveBlockData, error) {
+			ProcessBlockEventsCalled: func(eventsData *data.ArgsSaveBlockData) (*data.InterceptorBlockData, error) {
 				return nil, expectedErr
 			},
 		}
@@ -185,8 +185,8 @@ func TestHandlePushEvents(t *testing.T) {
 			},
 		}
 		args.EventsInterceptor = &mocks.EventsInterceptorStub{
-			ProcessBlockEventsCalled: func(eventsData *data.ArgsSaveBlockData) (*data.SaveBlockData, error) {
-				return &data.SaveBlockData{
+			ProcessBlockEventsCalled: func(eventsData *data.ArgsSaveBlockData) (*data.InterceptorBlockData, error) {
+				return &data.InterceptorBlockData{
 					Hash:      blockHash,
 					Txs:       expTxs,
 					Scrs:      expScrs,

--- a/integrationTests/rabbitmq/testNotifierWithRabbitMQ_test.go
+++ b/integrationTests/rabbitmq/testNotifierWithRabbitMQ_test.go
@@ -76,8 +76,15 @@ func pushEventsRequest(webServer *integrationTests.TestWebServer, mutResponses *
 				},
 			},
 		},
-		Body:   &block.Body{},
-		Header: &block.HeaderV2{},
+		Body: &block.Body{
+			MiniBlocks: make([]*block.MiniBlock, 1),
+		},
+		Header: &block.HeaderV2{
+			Header: &block.Header{
+				ShardID:   1,
+				TimeStamp: 1234,
+			},
+		},
 	}
 
 	resp := webServer.PushEventsRequest(blockEvents)

--- a/integrationTests/rabbitmq/testNotifierWithRabbitMQ_test.go
+++ b/integrationTests/rabbitmq/testNotifierWithRabbitMQ_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/ElrondNetwork/elrond-go-core/data/block"
 	"github.com/ElrondNetwork/elrond-go-core/data/smartContractResult"
 	"github.com/ElrondNetwork/elrond-go-core/data/transaction"
 	"github.com/ElrondNetwork/notifier-go/common"
@@ -75,6 +76,8 @@ func pushEventsRequest(webServer *integrationTests.TestWebServer, mutResponses *
 				},
 			},
 		},
+		Body:   &block.Body{},
+		Header: &block.HeaderV2{},
 	}
 
 	resp := webServer.PushEventsRequest(blockEvents)

--- a/integrationTests/websocket/testNotifierWithWebsockets_test.go
+++ b/integrationTests/websocket/testNotifierWithWebsockets_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/ElrondNetwork/elrond-go-core/data/block"
 	"github.com/ElrondNetwork/elrond-go-core/data/smartContractResult"
 	"github.com/ElrondNetwork/elrond-go-core/data/transaction"
 	"github.com/ElrondNetwork/notifier-go/common"
@@ -63,6 +64,8 @@ func TestNotifierWithWebsockets_PushEvents(t *testing.T) {
 				},
 			},
 		},
+		Body:   &block.Body{},
+		Header: &block.HeaderV2{},
 	}
 
 	wg := &sync.WaitGroup{}
@@ -215,6 +218,8 @@ func TestNotifierWithWebsockets_TxsEvents(t *testing.T) {
 		TransactionsPool: &data.TransactionsPool{
 			Txs: txs,
 		},
+		Body:   &block.Body{},
+		Header: &block.HeaderV2{},
 	}
 
 	expTxs := map[string]transaction.Transaction{
@@ -282,6 +287,8 @@ func TestNotifierWithWebsockets_ScrsEvents(t *testing.T) {
 		TransactionsPool: &data.TransactionsPool{
 			Scrs: scrs,
 		},
+		Body:   &block.Body{},
+		Header: &block.HeaderV2{},
 	}
 
 	expScrs := map[string]smartContractResult.SmartContractResult{
@@ -418,6 +425,8 @@ func TestNotifierWithWebsockets_AllEvents(t *testing.T) {
 				},
 			},
 		},
+		Body:   &block.Body{},
+		Header: &block.HeaderV2{},
 	}
 
 	numEvents := 5

--- a/integrationTests/websocket/testNotifierWithWebsockets_test.go
+++ b/integrationTests/websocket/testNotifierWithWebsockets_test.go
@@ -64,8 +64,15 @@ func TestNotifierWithWebsockets_PushEvents(t *testing.T) {
 				},
 			},
 		},
-		Body:   &block.Body{},
-		Header: &block.HeaderV2{},
+		Body: &block.Body{
+			MiniBlocks: make([]*block.MiniBlock, 1),
+		},
+		Header: &block.HeaderV2{
+			Header: &block.Header{
+				ShardID:   1,
+				TimeStamp: 1234,
+			},
+		},
 	}
 
 	wg := &sync.WaitGroup{}
@@ -224,8 +231,15 @@ func TestNotifierWithWebsockets_TxsEvents(t *testing.T) {
 		TransactionsPool: &data.TransactionsPool{
 			Txs: txs,
 		},
-		Body:   &block.Body{},
-		Header: &block.HeaderV2{},
+		Body: &block.Body{
+			MiniBlocks: make([]*block.MiniBlock, 1),
+		},
+		Header: &block.HeaderV2{
+			Header: &block.Header{
+				ShardID:   1,
+				TimeStamp: 1234,
+			},
+		},
 	}
 
 	expTxs := map[string]transaction.Transaction{
@@ -295,8 +309,15 @@ func TestNotifierWithWebsockets_ScrsEvents(t *testing.T) {
 		TransactionsPool: &data.TransactionsPool{
 			Scrs: scrs,
 		},
-		Body:   &block.Body{},
-		Header: &block.HeaderV2{},
+		Body: &block.Body{
+			MiniBlocks: make([]*block.MiniBlock, 1),
+		},
+		Header: &block.HeaderV2{
+			Header: &block.Header{
+				ShardID:   1,
+				TimeStamp: 1234,
+			},
+		},
 	}
 
 	expScrs := map[string]smartContractResult.SmartContractResult{

--- a/mocks/eventsInterceptorStub.go
+++ b/mocks/eventsInterceptorStub.go
@@ -4,11 +4,11 @@ import "github.com/ElrondNetwork/notifier-go/data"
 
 // EventsInterceptorStub -
 type EventsInterceptorStub struct {
-	ProcessBlockEventsCalled func(eventsData *data.ArgsSaveBlockData) (*data.SaveBlockData, error)
+	ProcessBlockEventsCalled func(eventsData *data.ArgsSaveBlockData) (*data.InterceptorBlockData, error)
 }
 
 // ProcessBlockEvents -
-func (stub *EventsInterceptorStub) ProcessBlockEvents(eventsData *data.ArgsSaveBlockData) (*data.SaveBlockData, error) {
+func (stub *EventsInterceptorStub) ProcessBlockEvents(eventsData *data.ArgsSaveBlockData) (*data.InterceptorBlockData, error) {
 	if stub.ProcessBlockEventsCalled != nil {
 		return stub.ProcessBlockEventsCalled(eventsData)
 	}

--- a/process/errors.go
+++ b/process/errors.go
@@ -19,3 +19,9 @@ var ErrNilBlockEvents = errors.New("nil block events provided")
 
 // ErrNilTransactionsPool signals that a nil transactions pool has been provided
 var ErrNilTransactionsPool = errors.New("nil transactions pool provided")
+
+// ErrNilBlockBody signals that a nil block body has been provided
+var ErrNilBlockBody = errors.New("nil block body provided")
+
+// ErrNilBlockHeader signals that a nil block header has been provided
+var ErrNilBlockHeader = errors.New("nil block header provided")

--- a/process/eventsHandler_test.go
+++ b/process/eventsHandler_test.go
@@ -92,7 +92,7 @@ func TestHandlePushEvents(t *testing.T) {
 	t.Run("check duplicates enabled, should not process event", func(t *testing.T) {
 		t.Parallel()
 
-		events := data.BlockEvents{
+		blockEvents := data.BlockEvents{
 			Hash:      "hash1",
 			ShardID:   1,
 			TimeStamp: 1234,
@@ -104,7 +104,7 @@ func TestHandlePushEvents(t *testing.T) {
 		args.Config.CheckDuplicates = true
 		args.Publisher = &mocks.PublisherStub{
 			BroadcastCalled: func(events data.BlockEvents) {
-				require.Equal(t, events, events)
+				require.Equal(t, blockEvents, events)
 				wasCalled = true
 			},
 		}
@@ -117,7 +117,7 @@ func TestHandlePushEvents(t *testing.T) {
 		eventsHandler, err := process.NewEventsHandler(args)
 		require.Nil(t, err)
 
-		eventsHandler.HandlePushEvents(events)
+		eventsHandler.HandlePushEvents(blockEvents)
 		require.False(t, wasCalled)
 	})
 }
@@ -151,7 +151,7 @@ func TestHandleRevertEvents(t *testing.T) {
 	t.Run("check duplicates enabled, should not process event", func(t *testing.T) {
 		t.Parallel()
 
-		events := data.RevertBlock{
+		revertEvents := data.RevertBlock{
 			Hash:  "hash1",
 			Nonce: 1,
 		}
@@ -161,7 +161,7 @@ func TestHandleRevertEvents(t *testing.T) {
 		args.Config.CheckDuplicates = true
 		args.Publisher = &mocks.PublisherStub{
 			BroadcastRevertCalled: func(events data.RevertBlock) {
-				require.Equal(t, events, events)
+				require.Equal(t, revertEvents, events)
 				wasCalled = true
 			},
 		}
@@ -174,7 +174,7 @@ func TestHandleRevertEvents(t *testing.T) {
 		eventsHandler, err := process.NewEventsHandler(args)
 		require.Nil(t, err)
 
-		eventsHandler.HandleRevertEvents(events)
+		eventsHandler.HandleRevertEvents(revertEvents)
 		require.False(t, wasCalled)
 	})
 }
@@ -185,7 +185,7 @@ func TestHandleFinalizedEvents(t *testing.T) {
 	t.Run("broadcast finalized event was called", func(t *testing.T) {
 		t.Parallel()
 
-		events := data.FinalizedBlock{
+		finalizedEvents := data.FinalizedBlock{
 			Hash: "hash1",
 		}
 
@@ -193,7 +193,7 @@ func TestHandleFinalizedEvents(t *testing.T) {
 		args := createMockEventsHandlerArgs()
 		args.Publisher = &mocks.PublisherStub{
 			BroadcastFinalizedCalled: func(events data.FinalizedBlock) {
-				require.Equal(t, events, events)
+				require.Equal(t, finalizedEvents, events)
 				wasCalled = true
 			},
 		}
@@ -201,7 +201,7 @@ func TestHandleFinalizedEvents(t *testing.T) {
 		eventsHandler, err := process.NewEventsHandler(args)
 		require.Nil(t, err)
 
-		eventsHandler.HandleFinalizedEvents(events)
+		eventsHandler.HandleFinalizedEvents(finalizedEvents)
 		require.True(t, wasCalled)
 	})
 
@@ -240,7 +240,7 @@ func TestHandleTxsEvents(t *testing.T) {
 	t.Run("broadcast txs event was called", func(t *testing.T) {
 		t.Parallel()
 
-		events := data.BlockTxs{
+		blockTxs := data.BlockTxs{
 			Hash: "hash1",
 			Txs: map[string]transaction.Transaction{
 				"hash1": {
@@ -253,7 +253,7 @@ func TestHandleTxsEvents(t *testing.T) {
 		args := createMockEventsHandlerArgs()
 		args.Publisher = &mocks.PublisherStub{
 			BroadcastTxsCalled: func(event data.BlockTxs) {
-				require.Equal(t, events, events)
+				require.Equal(t, blockTxs, event)
 				wasCalled = true
 			},
 		}
@@ -261,14 +261,14 @@ func TestHandleTxsEvents(t *testing.T) {
 		eventsHandler, err := process.NewEventsHandler(args)
 		require.Nil(t, err)
 
-		eventsHandler.HandleBlockTxs(events)
+		eventsHandler.HandleBlockTxs(blockTxs)
 		require.True(t, wasCalled)
 	})
 
 	t.Run("check duplicates enabled, should not process event", func(t *testing.T) {
 		t.Parallel()
 
-		events := data.BlockTxs{
+		blockTxs := data.BlockTxs{
 			Hash: "hash1",
 			Txs: map[string]transaction.Transaction{
 				"hash1": {
@@ -282,7 +282,7 @@ func TestHandleTxsEvents(t *testing.T) {
 		args.Config.CheckDuplicates = true
 		args.Publisher = &mocks.PublisherStub{
 			BroadcastTxsCalled: func(event data.BlockTxs) {
-				require.Equal(t, events, events)
+				require.Equal(t, blockTxs, event)
 				wasCalled = true
 			},
 		}
@@ -295,7 +295,7 @@ func TestHandleTxsEvents(t *testing.T) {
 		eventsHandler, err := process.NewEventsHandler(args)
 		require.Nil(t, err)
 
-		eventsHandler.HandleBlockTxs(events)
+		eventsHandler.HandleBlockTxs(blockTxs)
 		require.False(t, wasCalled)
 	})
 }
@@ -306,7 +306,7 @@ func TestHandleScrsEvents(t *testing.T) {
 	t.Run("broadcast scrs event was called", func(t *testing.T) {
 		t.Parallel()
 
-		events := data.BlockScrs{
+		blockScrs := data.BlockScrs{
 			Hash: "hash1",
 			Scrs: map[string]smartContractResult.SmartContractResult{
 				"hash2": {
@@ -319,7 +319,7 @@ func TestHandleScrsEvents(t *testing.T) {
 		args := createMockEventsHandlerArgs()
 		args.Publisher = &mocks.PublisherStub{
 			BroadcastScrsCalled: func(event data.BlockScrs) {
-				require.Equal(t, events, events)
+				require.Equal(t, blockScrs, event)
 				wasCalled = true
 			},
 		}
@@ -327,7 +327,7 @@ func TestHandleScrsEvents(t *testing.T) {
 		eventsHandler, err := process.NewEventsHandler(args)
 		require.Nil(t, err)
 
-		eventsHandler.HandleBlockScrs(events)
+		eventsHandler.HandleBlockScrs(blockScrs)
 		require.True(t, wasCalled)
 	})
 

--- a/process/eventsInterceptor.go
+++ b/process/eventsInterceptor.go
@@ -59,6 +59,8 @@ func (ei *eventsInterceptor) ProcessBlockEvents(eventsData *data.ArgsSaveBlockDa
 
 	return &data.InterceptorBlockData{
 		Hash:      hex.EncodeToString(eventsData.HeaderHash),
+		Body:      eventsData.Body,
+		Header:    eventsData.Header,
 		Txs:       txs,
 		Scrs:      scrs,
 		LogEvents: events,

--- a/process/eventsInterceptor.go
+++ b/process/eventsInterceptor.go
@@ -31,12 +31,18 @@ func NewEventsInterceptor(args ArgsEventsInterceptor) (*eventsInterceptor, error
 }
 
 // ProcessBlockEvents will process block events data
-func (ei *eventsInterceptor) ProcessBlockEvents(eventsData *data.ArgsSaveBlockData) (*data.SaveBlockData, error) {
+func (ei *eventsInterceptor) ProcessBlockEvents(eventsData *data.ArgsSaveBlockData) (*data.InterceptorBlockData, error) {
 	if eventsData == nil {
 		return nil, ErrNilBlockEvents
 	}
 	if eventsData.TransactionsPool == nil {
 		return nil, ErrNilTransactionsPool
+	}
+	if eventsData.Body == nil {
+		return nil, ErrNilBlockBody
+	}
+	if eventsData.Header == nil {
+		return nil, ErrNilBlockHeader
 	}
 
 	events := ei.getLogEventsFromTransactionsPool(eventsData.TransactionsPool.Logs)
@@ -51,7 +57,7 @@ func (ei *eventsInterceptor) ProcessBlockEvents(eventsData *data.ArgsSaveBlockDa
 		scrs[hash] = scr.SmartContractResult
 	}
 
-	return &data.SaveBlockData{
+	return &data.InterceptorBlockData{
 		Hash:      hex.EncodeToString(eventsData.HeaderHash),
 		Txs:       txs,
 		Scrs:      scrs,

--- a/process/eventsInterceptor_test.go
+++ b/process/eventsInterceptor_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/ElrondNetwork/elrond-go-core/core/check"
+	"github.com/ElrondNetwork/elrond-go-core/data/block"
 	"github.com/ElrondNetwork/elrond-go-core/data/smartContractResult"
 	"github.com/ElrondNetwork/elrond-go-core/data/transaction"
 	"github.com/ElrondNetwork/notifier-go/data"
@@ -68,6 +69,37 @@ func TestProcessBlockEvents(t *testing.T) {
 		require.Equal(t, process.ErrNilTransactionsPool, err)
 	})
 
+	t.Run("nil block body", func(t *testing.T) {
+		t.Parallel()
+
+		eventsInterceptor, _ := process.NewEventsInterceptor(createMockEventsInterceptorArgs())
+
+		eventsData := &data.ArgsSaveBlockData{
+			HeaderHash:       []byte("headerHash"),
+			TransactionsPool: &data.TransactionsPool{},
+			Body:             nil,
+		}
+		events, err := eventsInterceptor.ProcessBlockEvents(eventsData)
+		require.Nil(t, events)
+		require.Equal(t, process.ErrNilBlockBody, err)
+	})
+
+	t.Run("nil block header", func(t *testing.T) {
+		t.Parallel()
+
+		eventsInterceptor, _ := process.NewEventsInterceptor(createMockEventsInterceptorArgs())
+
+		eventsData := &data.ArgsSaveBlockData{
+			HeaderHash:       []byte("headerHash"),
+			TransactionsPool: &data.TransactionsPool{},
+			Body:             &block.Body{},
+			Header:           nil,
+		}
+		events, err := eventsInterceptor.ProcessBlockEvents(eventsData)
+		require.Nil(t, events)
+		require.Equal(t, process.ErrNilBlockHeader, err)
+	})
+
 	t.Run("should work", func(t *testing.T) {
 		t.Parallel()
 
@@ -94,6 +126,8 @@ func TestProcessBlockEvents(t *testing.T) {
 		blockHash := []byte("blockHash")
 		blockEvents := data.ArgsSaveBlockData{
 			HeaderHash: blockHash,
+			Body:       &block.Body{},
+			Header:     &block.HeaderV2{},
 			TransactionsPool: &data.TransactionsPool{
 				Txs:  txs,
 				Scrs: scrs,
@@ -123,7 +157,7 @@ func TestProcessBlockEvents(t *testing.T) {
 			},
 		}
 
-		expEvents := &data.SaveBlockData{
+		expEvents := &data.InterceptorBlockData{
 			Hash: hex.EncodeToString(blockHash),
 			Txs:  expTxs,
 			Scrs: expScrs,

--- a/process/eventsInterceptor_test.go
+++ b/process/eventsInterceptor_test.go
@@ -123,11 +123,20 @@ func TestProcessBlockEvents(t *testing.T) {
 		}
 		addr := []byte("addr1")
 
+		blockBody := &block.Body{
+			MiniBlocks: make([]*block.MiniBlock, 1),
+		}
+		blockHeader := &block.HeaderV2{
+			Header: &block.Header{
+				ShardID:   1,
+				TimeStamp: 1234,
+			},
+		}
 		blockHash := []byte("blockHash")
 		blockEvents := data.ArgsSaveBlockData{
 			HeaderHash: blockHash,
-			Body:       &block.Body{},
-			Header:     &block.HeaderV2{},
+			Body:       blockBody,
+			Header:     blockHeader,
 			TransactionsPool: &data.TransactionsPool{
 				Txs:  txs,
 				Scrs: scrs,
@@ -158,9 +167,11 @@ func TestProcessBlockEvents(t *testing.T) {
 		}
 
 		expEvents := &data.InterceptorBlockData{
-			Hash: hex.EncodeToString(blockHash),
-			Txs:  expTxs,
-			Scrs: expScrs,
+			Hash:   hex.EncodeToString(blockHash),
+			Body:   blockBody,
+			Header: blockHeader,
+			Txs:    expTxs,
+			Scrs:   expScrs,
 			LogEvents: []data.Event{
 				{
 					Address: hex.EncodeToString(addr),

--- a/process/interface.go
+++ b/process/interface.go
@@ -37,6 +37,6 @@ type EventsHandler interface {
 
 // EventsInterceptor defines the behaviour of an events interceptor component
 type EventsInterceptor interface {
-	ProcessBlockEvents(eventsData *data.ArgsSaveBlockData) (*data.SaveBlockData, error)
+	ProcessBlockEvents(eventsData *data.ArgsSaveBlockData) (*data.InterceptorBlockData, error)
 	IsInterfaceNil() bool
 }


### PR DESCRIPTION
Add 2 additional fields for rabbitmq publisher: `ShardId`, `Timestamp`
Fix websocket timeout blocking in integration tests.

Additional cleanup for old push data will be done in a future PR.