### PR TITLE
Handling for full block events channel

### DIFF
--- a/cmd/notifier/config/config.toml
+++ b/cmd/notifier/config/config.toml
@@ -64,3 +64,8 @@
     [RabbitMQ.BlockScrsExchange]
         Name = "block_scrs"
         Type = "fanout"
+
+    # The exchange which holds block txs with order events
+    [RabbitMQ.BlockTxsWithOrderExchange]
+        Name = "block_txs_with_order"
+        Type = "fanout"

--- a/cmd/notifier/config/config.toml
+++ b/cmd/notifier/config/config.toml
@@ -65,7 +65,7 @@
         Name = "block_scrs"
         Type = "fanout"
 
-    # The exchange which holds block txs with order events
-    [RabbitMQ.BlockTxsWithOrderExchange]
-        Name = "block_txs_with_order"
+    # The exchange which holds block events with additional info
+    [RabbitMQ.BlockEventsExchange]
+        Name = "block_events"
         Type = "fanout"

--- a/common/constants.go
+++ b/common/constants.go
@@ -35,6 +35,9 @@ const (
 	// BlockTxs defines the subscription event type for block txs
 	BlockTxs string = "block_txs"
 
+	// BlockTxsWithOrder defines the subscription event type for block txs with order
+	BlockTxsWithOrder string = "block_txs_with_order"
+
 	// BlockScrs defines the subscription event type for block scrs
 	BlockScrs string = "block_scrs"
 )

--- a/common/constants.go
+++ b/common/constants.go
@@ -35,8 +35,8 @@ const (
 	// BlockTxs defines the subscription event type for block txs
 	BlockTxs string = "block_txs"
 
-	// BlockTxsWithOrder defines the subscription event type for block txs with order
-	BlockTxsWithOrder string = "block_txs_with_order"
+	// BlockEventsWithOrder defines the subscription event type for block events with order
+	BlockEventsWithOrder string = "block_events_with_order"
 
 	// BlockScrs defines the subscription event type for block scrs
 	BlockScrs string = "block_scrs"

--- a/config/config.go
+++ b/config/config.go
@@ -30,13 +30,13 @@ type RedisConfig struct {
 
 // RabbitMQConfig maps the rabbitMQ configuration
 type RabbitMQConfig struct {
-	Url                       string
-	EventsExchange            RabbitMQExchangeConfig
-	RevertEventsExchange      RabbitMQExchangeConfig
-	FinalizedEventsExchange   RabbitMQExchangeConfig
-	BlockTxsExchange          RabbitMQExchangeConfig
-	BlockScrsExchange         RabbitMQExchangeConfig
-	BlockTxsWithOrderExchange RabbitMQExchangeConfig
+	Url                     string
+	EventsExchange          RabbitMQExchangeConfig
+	RevertEventsExchange    RabbitMQExchangeConfig
+	FinalizedEventsExchange RabbitMQExchangeConfig
+	BlockTxsExchange        RabbitMQExchangeConfig
+	BlockScrsExchange       RabbitMQExchangeConfig
+	BlockEventsExchange     RabbitMQExchangeConfig
 }
 
 // RabbitMQExchangeConfig holds the configuration for a rabbitMQ exchange

--- a/config/config.go
+++ b/config/config.go
@@ -30,12 +30,13 @@ type RedisConfig struct {
 
 // RabbitMQConfig maps the rabbitMQ configuration
 type RabbitMQConfig struct {
-	Url                     string
-	EventsExchange          RabbitMQExchangeConfig
-	RevertEventsExchange    RabbitMQExchangeConfig
-	FinalizedEventsExchange RabbitMQExchangeConfig
-	BlockTxsExchange        RabbitMQExchangeConfig
-	BlockScrsExchange       RabbitMQExchangeConfig
+	Url                       string
+	EventsExchange            RabbitMQExchangeConfig
+	RevertEventsExchange      RabbitMQExchangeConfig
+	FinalizedEventsExchange   RabbitMQExchangeConfig
+	BlockTxsExchange          RabbitMQExchangeConfig
+	BlockScrsExchange         RabbitMQExchangeConfig
+	BlockTxsWithOrderExchange RabbitMQExchangeConfig
 }
 
 // RabbitMQExchangeConfig holds the configuration for a rabbitMQ exchange

--- a/data/transaction.go
+++ b/data/transaction.go
@@ -67,6 +67,14 @@ type BlockTxs struct {
 	Txs  map[string]transaction.Transaction `json:"txs"`
 }
 
+// BlockTxsWithOrder holds the block transactions with order
+type BlockTxsWithOrder struct {
+	Hash      string                          `json:"hash"`
+	ShardID   uint32                          `json:"shardId"`
+	TimeStamp uint64                          `json:"timestamp"`
+	Txs       map[string]TransactionWithOrder `json:"txs"`
+}
+
 // BlockScrs holds the block smart contract results
 // TODO: set scr with order here also
 type BlockScrs struct {
@@ -84,12 +92,13 @@ type SaveBlockData struct {
 
 // InterceptorBlockData holds the block data needed for processing
 type InterceptorBlockData struct {
-	Hash      string
-	Body      *block.Body
-	Header    *block.HeaderV2
-	Txs       map[string]transaction.Transaction
-	Scrs      map[string]smartContractResult.SmartContractResult
-	LogEvents []Event
+	Hash         string
+	Body         *block.Body
+	Header       *block.HeaderV2
+	Txs          map[string]transaction.Transaction
+	TxsWithOrder map[string]TransactionWithOrder
+	Scrs         map[string]smartContractResult.SmartContractResult
+	LogEvents    []Event
 }
 
 // ArgsSaveBlockData will contain all information that are needed to save block data

--- a/data/transaction.go
+++ b/data/transaction.go
@@ -63,16 +63,19 @@ type FinalizedBlock struct {
 // BlockTxs holds the block transactions
 // TODO: set transaction with order here also
 type BlockTxs struct {
-	Hash string                             `json:"hash"`
-	Txs  map[string]transaction.Transaction `json:"txs"`
+	Hash   string                             `json:"hash"`
+	Txs    map[string]transaction.Transaction `json:"txs"`
+	Events []Event                            `json:"events"`
 }
 
 // BlockEventsWithOrder holds the block transactions with order
 type BlockEventsWithOrder struct {
-	Hash      string                          `json:"hash"`
-	ShardID   uint32                          `json:"shardId"`
-	TimeStamp uint64                          `json:"timestamp"`
-	Txs       map[string]TransactionWithOrder `json:"txs"`
+	Hash      string                                  `json:"hash"`
+	ShardID   uint32                                  `json:"shardId"`
+	TimeStamp uint64                                  `json:"timestamp"`
+	Txs       map[string]TransactionWithOrder         `json:"txs"`
+	Scrs      map[string]SmartContractResultWithOrder `json:"scrs"`
+	Events    []Event                                 `json:"events"`
 }
 
 // BlockScrs holds the block smart contract results
@@ -92,13 +95,14 @@ type SaveBlockData struct {
 
 // InterceptorBlockData holds the block data needed for processing
 type InterceptorBlockData struct {
-	Hash         string
-	Body         *block.Body
-	Header       *block.HeaderV2
-	Txs          map[string]transaction.Transaction
-	TxsWithOrder map[string]TransactionWithOrder
-	Scrs         map[string]smartContractResult.SmartContractResult
-	LogEvents    []Event
+	Hash          string
+	Body          *block.Body
+	Header        *block.HeaderV2
+	Txs           map[string]transaction.Transaction
+	TxsWithOrder  map[string]TransactionWithOrder
+	Scrs          map[string]smartContractResult.SmartContractResult
+	ScrsWithOrder map[string]SmartContractResultWithOrder
+	LogEvents     []Event
 }
 
 // ArgsSaveBlockData will contain all information that are needed to save block data

--- a/data/transaction.go
+++ b/data/transaction.go
@@ -67,8 +67,8 @@ type BlockTxs struct {
 	Txs  map[string]transaction.Transaction `json:"txs"`
 }
 
-// BlockTxsWithOrder holds the block transactions with order
-type BlockTxsWithOrder struct {
+// BlockEventsWithOrder holds the block transactions with order
+type BlockEventsWithOrder struct {
 	Hash      string                          `json:"hash"`
 	ShardID   uint32                          `json:"shardId"`
 	TimeStamp uint64                          `json:"timestamp"`

--- a/data/transaction.go
+++ b/data/transaction.go
@@ -71,7 +71,7 @@ type BlockTxs struct {
 // BlockEventsWithOrder holds the block transactions with order
 type BlockEventsWithOrder struct {
 	Hash      string                                  `json:"hash"`
-	ShardID   uint32                                  `json:"shardId"`
+	ShardID   uint32                                  `json:"shardID"`
 	TimeStamp uint64                                  `json:"timestamp"`
 	Txs       map[string]TransactionWithOrder         `json:"txs"`
 	Scrs      map[string]SmartContractResultWithOrder `json:"scrs"`

--- a/disabled/disabledHub.go
+++ b/disabled/disabledHub.go
@@ -33,6 +33,10 @@ func (h *Hub) BroadcastTxs(_ data.BlockTxs) {
 func (h *Hub) BroadcastScrs(_ data.BlockScrs) {
 }
 
+// BroadcastTxsWithOrder does nothing
+func (h *Hub) BroadcastTxsWithOrder(_ data.BlockTxsWithOrder) {
+}
+
 // RegisterEvent does nothing
 func (h *Hub) RegisterEvent(_ dispatcher.EventDispatcher) {
 }

--- a/disabled/disabledHub.go
+++ b/disabled/disabledHub.go
@@ -33,8 +33,8 @@ func (h *Hub) BroadcastTxs(_ data.BlockTxs) {
 func (h *Hub) BroadcastScrs(_ data.BlockScrs) {
 }
 
-// BroadcastTxsWithOrder does nothing
-func (h *Hub) BroadcastTxsWithOrder(_ data.BlockTxsWithOrder) {
+// BroadcastBlockEventsWithOrder does nothing
+func (h *Hub) BroadcastBlockEventsWithOrder(_ data.BlockEventsWithOrder) {
 }
 
 // RegisterEvent does nothing

--- a/disabled/disabledPublisher.go
+++ b/disabled/disabledPublisher.go
@@ -31,6 +31,10 @@ func (dp *Publisher) BroadcastTxs(_ data.BlockTxs) {
 func (dp *Publisher) BroadcastScrs(_ data.BlockScrs) {
 }
 
+// BroadcastTxsWithOrder does nothing
+func (dp *Publisher) BroadcastTxsWithOrder(_ data.BlockTxsWithOrder) {
+}
+
 // Close returns nil
 func (dp *Publisher) Close() error {
 	return nil

--- a/disabled/disabledPublisher.go
+++ b/disabled/disabledPublisher.go
@@ -31,8 +31,8 @@ func (dp *Publisher) BroadcastTxs(_ data.BlockTxs) {
 func (dp *Publisher) BroadcastScrs(_ data.BlockScrs) {
 }
 
-// BroadcastTxsWithOrder does nothing
-func (dp *Publisher) BroadcastTxsWithOrder(_ data.BlockTxsWithOrder) {
+// BroadcastBlockEventsWithOrder does nothing
+func (dp *Publisher) BroadcastBlockEventsWithOrder(_ data.BlockEventsWithOrder) {
 }
 
 // Close returns nil

--- a/dispatcher/hub/commonHub.go
+++ b/dispatcher/hub/commonHub.go
@@ -160,6 +160,11 @@ func (ch *commonHub) BroadcastScrs(event data.BlockScrs) {
 	}
 }
 
+// BlockTxsWithOrder not implemented yet
+func (ch *commonHub) BroadcastTxsWithOrder(event data.BlockTxsWithOrder) {
+	log.Error("BroadcastTxsWithOrder: not implemented")
+}
+
 // RegisterEvent will send event to a receive-only channel used to register dispatchers
 func (ch *commonHub) RegisterEvent(event dispatcher.EventDispatcher) {
 	select {

--- a/dispatcher/hub/commonHub.go
+++ b/dispatcher/hub/commonHub.go
@@ -22,20 +22,20 @@ type ArgsCommonHub struct {
 }
 
 type commonHub struct {
-	filter                filters.EventFilter
-	subscriptionMapper    dispatcher.SubscriptionMapperHandler
-	mutDispatchers        sync.RWMutex
-	dispatchers           map[uuid.UUID]dispatcher.EventDispatcher
-	register              chan dispatcher.EventDispatcher
-	unregister            chan dispatcher.EventDispatcher
-	broadcast             chan data.BlockEvents
-	broadcastRevert       chan data.RevertBlock
-	broadcastFinalized    chan data.FinalizedBlock
-	broadcastTxs          chan data.BlockTxs
-	broadcastTxsWithOrder chan data.BlockTxsWithOrder
-	broadcastScrs         chan data.BlockScrs
-	closeChan             chan struct{}
-	cancelFunc            func()
+	filter                        filters.EventFilter
+	subscriptionMapper            dispatcher.SubscriptionMapperHandler
+	mutDispatchers                sync.RWMutex
+	dispatchers                   map[uuid.UUID]dispatcher.EventDispatcher
+	register                      chan dispatcher.EventDispatcher
+	unregister                    chan dispatcher.EventDispatcher
+	broadcast                     chan data.BlockEvents
+	broadcastRevert               chan data.RevertBlock
+	broadcastFinalized            chan data.FinalizedBlock
+	broadcastTxs                  chan data.BlockTxs
+	broadcastBlockEventsWithOrder chan data.BlockEventsWithOrder
+	broadcastScrs                 chan data.BlockScrs
+	closeChan                     chan struct{}
+	cancelFunc                    func()
 }
 
 // NewCommonHub creates a new commonHub instance
@@ -46,19 +46,19 @@ func NewCommonHub(args ArgsCommonHub) (*commonHub, error) {
 	}
 
 	return &commonHub{
-		mutDispatchers:        sync.RWMutex{},
-		filter:                args.Filter,
-		subscriptionMapper:    args.SubscriptionMapper,
-		dispatchers:           make(map[uuid.UUID]dispatcher.EventDispatcher),
-		register:              make(chan dispatcher.EventDispatcher),
-		unregister:            make(chan dispatcher.EventDispatcher),
-		broadcast:             make(chan data.BlockEvents),
-		broadcastRevert:       make(chan data.RevertBlock),
-		broadcastFinalized:    make(chan data.FinalizedBlock),
-		broadcastTxs:          make(chan data.BlockTxs),
-		broadcastTxsWithOrder: make(chan data.BlockTxsWithOrder),
-		broadcastScrs:         make(chan data.BlockScrs),
-		closeChan:             make(chan struct{}),
+		mutDispatchers:                sync.RWMutex{},
+		filter:                        args.Filter,
+		subscriptionMapper:            args.SubscriptionMapper,
+		dispatchers:                   make(map[uuid.UUID]dispatcher.EventDispatcher),
+		register:                      make(chan dispatcher.EventDispatcher),
+		unregister:                    make(chan dispatcher.EventDispatcher),
+		broadcast:                     make(chan data.BlockEvents),
+		broadcastRevert:               make(chan data.RevertBlock),
+		broadcastFinalized:            make(chan data.FinalizedBlock),
+		broadcastTxs:                  make(chan data.BlockTxs),
+		broadcastBlockEventsWithOrder: make(chan data.BlockEventsWithOrder),
+		broadcastScrs:                 make(chan data.BlockScrs),
+		closeChan:                     make(chan struct{}),
 	}, nil
 }
 
@@ -100,8 +100,8 @@ func (ch *commonHub) run(ctx context.Context) {
 		case txsEvent := <-ch.broadcastTxs:
 			ch.handleTxsBroadcast(txsEvent)
 
-		case txsEvent := <-ch.broadcastTxsWithOrder:
-			ch.handleTxsWithOrderBroadcast(txsEvent)
+		case txsEvent := <-ch.broadcastBlockEventsWithOrder:
+			ch.handleBlockEventsWithOrderBroadcast(txsEvent)
 
 		case scrsEvent := <-ch.broadcastScrs:
 			ch.handleScrsBroadcast(scrsEvent)
@@ -165,10 +165,10 @@ func (ch *commonHub) BroadcastScrs(event data.BlockScrs) {
 	}
 }
 
-// BlockTxsWithOrder not implemented yet
-func (ch *commonHub) BroadcastTxsWithOrder(event data.BlockTxsWithOrder) {
+// BroadcastBlockEventsWithOrder handles full block events pushed by producers into the channel
+func (ch *commonHub) BroadcastBlockEventsWithOrder(event data.BlockEventsWithOrder) {
 	select {
-	case ch.broadcastTxsWithOrder <- event:
+	case ch.broadcastBlockEventsWithOrder <- event:
 	case <-ch.closeChan:
 	}
 }
@@ -309,13 +309,13 @@ func (ch *commonHub) handleTxsBroadcast(blockTxs data.BlockTxs) {
 	}
 }
 
-func (ch *commonHub) handleTxsWithOrderBroadcast(blockTxs data.BlockTxsWithOrder) {
+func (ch *commonHub) handleBlockEventsWithOrderBroadcast(blockTxs data.BlockEventsWithOrder) {
 	subscriptions := ch.subscriptionMapper.Subscriptions()
 
-	dispatchersMap := make(map[uuid.UUID]data.BlockTxsWithOrder)
+	dispatchersMap := make(map[uuid.UUID]data.BlockEventsWithOrder)
 
 	for _, subscription := range subscriptions {
-		if subscription.EventType != common.BlockTxsWithOrder {
+		if subscription.EventType != common.BlockEventsWithOrder {
 			continue
 		}
 
@@ -326,7 +326,7 @@ func (ch *commonHub) handleTxsWithOrderBroadcast(blockTxs data.BlockTxsWithOrder
 	defer ch.mutDispatchers.RUnlock()
 	for id, event := range dispatchersMap {
 		if d, ok := ch.dispatchers[id]; ok {
-			d.TxsWithOrderEvent(event)
+			d.BlockEventsWithOrder(event)
 		}
 	}
 }

--- a/dispatcher/hub/commonHub_test.go
+++ b/dispatcher/hub/commonHub_test.go
@@ -335,7 +335,7 @@ func TestCommonHub_HandleTxsBroadcast(t *testing.T) {
 	assert.Equal(t, uint32(1), atomic.LoadUint32(&numCalls))
 }
 
-func TestCommonHub_HandleTxsWithOrderBroadcast(t *testing.T) {
+func TestCommonHub_HandleBlockEventsWithOrderBroadcast(t *testing.T) {
 	t.Parallel()
 
 	args := createMockCommonHubArgs()
@@ -344,7 +344,7 @@ func TestCommonHub_HandleTxsWithOrderBroadcast(t *testing.T) {
 
 	numCalls := uint32(0)
 	hub.registerDispatcher(&mocks.DispatcherStub{
-		TxsWithOrderEventCalled: func(event data.BlockTxsWithOrder) {
+		BlockEventsWithOrderCalled: func(event data.BlockEventsWithOrder) {
 			atomic.AddUint32(&numCalls, 1)
 		},
 	})
@@ -352,7 +352,7 @@ func TestCommonHub_HandleTxsWithOrderBroadcast(t *testing.T) {
 	hub.Subscribe(data.SubscribeEvent{
 		SubscriptionEntries: []data.SubscriptionEntry{
 			{
-				EventType: common.BlockTxsWithOrder,
+				EventType: common.BlockEventsWithOrder,
 			},
 		},
 	})
@@ -360,11 +360,11 @@ func TestCommonHub_HandleTxsWithOrderBroadcast(t *testing.T) {
 	hub.Run()
 	defer hub.Close()
 
-	blockEvents := data.BlockTxsWithOrder{
+	blockEvents := data.BlockEventsWithOrder{
 		Hash: "hash1",
 	}
 
-	hub.BroadcastTxsWithOrder(blockEvents)
+	hub.handleBlockEventsWithOrderBroadcast(blockEvents)
 
 	time.Sleep(time.Millisecond * 100)
 

--- a/dispatcher/interface.go
+++ b/dispatcher/interface.go
@@ -17,7 +17,7 @@ type EventDispatcher interface {
 	RevertEvent(event data.RevertBlock)
 	FinalizedEvent(event data.FinalizedBlock)
 	TxsEvent(event data.BlockTxs)
-	TxsWithOrderEvent(event data.BlockTxsWithOrder)
+	BlockEventsWithOrder(event data.BlockEventsWithOrder)
 	ScrsEvent(event data.BlockScrs)
 }
 
@@ -30,7 +30,7 @@ type Hub interface {
 	BroadcastFinalized(event data.FinalizedBlock)
 	BroadcastTxs(event data.BlockTxs)
 	BroadcastScrs(event data.BlockScrs)
-	BroadcastTxsWithOrder(event data.BlockTxsWithOrder)
+	BroadcastBlockEventsWithOrder(event data.BlockEventsWithOrder)
 	RegisterEvent(event EventDispatcher)
 	UnregisterEvent(event EventDispatcher)
 	Subscribe(event data.SubscribeEvent)

--- a/dispatcher/interface.go
+++ b/dispatcher/interface.go
@@ -28,6 +28,7 @@ type Hub interface {
 	BroadcastFinalized(event data.FinalizedBlock)
 	BroadcastTxs(event data.BlockTxs)
 	BroadcastScrs(event data.BlockScrs)
+	BroadcastTxsWithOrder(event data.BlockTxsWithOrder)
 	RegisterEvent(event EventDispatcher)
 	UnregisterEvent(event EventDispatcher)
 	Subscribe(event data.SubscribeEvent)

--- a/dispatcher/interface.go
+++ b/dispatcher/interface.go
@@ -17,6 +17,7 @@ type EventDispatcher interface {
 	RevertEvent(event data.RevertBlock)
 	FinalizedEvent(event data.FinalizedBlock)
 	TxsEvent(event data.BlockTxs)
+	TxsWithOrderEvent(event data.BlockTxsWithOrder)
 	ScrsEvent(event data.BlockScrs)
 }
 

--- a/dispatcher/subscription.go
+++ b/dispatcher/subscription.go
@@ -142,6 +142,7 @@ func getEventType(subEntry data.SubscriptionEntry) string {
 	if subEntry.EventType == common.FinalizedBlockEvents ||
 		subEntry.EventType == common.RevertBlockEvents ||
 		subEntry.EventType == common.BlockTxs ||
+		subEntry.EventType == common.BlockTxsWithOrder ||
 		subEntry.EventType == common.BlockScrs ||
 		subEntry.EventType == common.PushBlockEvents {
 		return subEntry.EventType

--- a/dispatcher/subscription.go
+++ b/dispatcher/subscription.go
@@ -142,7 +142,7 @@ func getEventType(subEntry data.SubscriptionEntry) string {
 	if subEntry.EventType == common.FinalizedBlockEvents ||
 		subEntry.EventType == common.RevertBlockEvents ||
 		subEntry.EventType == common.BlockTxs ||
-		subEntry.EventType == common.BlockTxsWithOrder ||
+		subEntry.EventType == common.BlockEventsWithOrder ||
 		subEntry.EventType == common.BlockScrs ||
 		subEntry.EventType == common.PushBlockEvents {
 		return subEntry.EventType

--- a/dispatcher/ws/wsDispatcher.go
+++ b/dispatcher/ws/wsDispatcher.go
@@ -168,15 +168,15 @@ func (wd *websocketDispatcher) TxsEvent(event data.BlockTxs) {
 	wd.send <- wsEventBytes
 }
 
-// TxsWithOrderEvent receives a block txs with order event and process it before pushing to socket
-func (wd *websocketDispatcher) TxsWithOrderEvent(event data.BlockTxsWithOrder) {
+// BlockEventsWithOrder receives a block txs with order event and process it before pushing to socket
+func (wd *websocketDispatcher) BlockEventsWithOrder(event data.BlockEventsWithOrder) {
 	eventBytes, err := json.Marshal(event)
 	if err != nil {
 		log.Error("failure marshalling events", "err", err.Error())
 		return
 	}
 	wsEvent := &data.WSEvent{
-		Type: common.BlockTxsWithOrder,
+		Type: common.BlockEventsWithOrder,
 		Data: eventBytes,
 	}
 	wsEventBytes, err := json.Marshal(wsEvent)

--- a/dispatcher/ws/wsDispatcher.go
+++ b/dispatcher/ws/wsDispatcher.go
@@ -168,6 +168,26 @@ func (wd *websocketDispatcher) TxsEvent(event data.BlockTxs) {
 	wd.send <- wsEventBytes
 }
 
+// TxsWithOrderEvent receives a block txs with order event and process it before pushing to socket
+func (wd *websocketDispatcher) TxsWithOrderEvent(event data.BlockTxsWithOrder) {
+	eventBytes, err := json.Marshal(event)
+	if err != nil {
+		log.Error("failure marshalling events", "err", err.Error())
+		return
+	}
+	wsEvent := &data.WSEvent{
+		Type: common.BlockTxsWithOrder,
+		Data: eventBytes,
+	}
+	wsEventBytes, err := json.Marshal(wsEvent)
+	if err != nil {
+		log.Error("failure marshalling events", "err", err.Error())
+		return
+	}
+
+	wd.send <- wsEventBytes
+}
+
 // ScrsEvent receives a block scrs event and process it before pushing to socket
 func (wd *websocketDispatcher) ScrsEvent(event data.BlockScrs) {
 	eventBytes, err := json.Marshal(event)

--- a/dispatcher/ws/wsDispatcher_test.go
+++ b/dispatcher/ws/wsDispatcher_test.go
@@ -6,6 +6,7 @@ import (
 	"io"
 	"testing"
 
+	"github.com/ElrondNetwork/elrond-go-core/data/transaction"
 	"github.com/ElrondNetwork/notifier-go/common"
 	"github.com/ElrondNetwork/notifier-go/data"
 	"github.com/ElrondNetwork/notifier-go/dispatcher/ws"
@@ -191,6 +192,43 @@ func TestBlockEvents(t *testing.T) {
 
 	wsEvent := &data.WSEvent{
 		Type: common.PushBlockEvents,
+		Data: blockDataBytes,
+	}
+	expectedEventBytes, _ := json.Marshal(wsEvent)
+
+	eventsData := wd.ReadSendChannel()
+
+	require.Equal(t, expectedEventBytes, eventsData)
+}
+
+func TestTxsWithOrderEvents(t *testing.T) {
+	t.Parallel()
+
+	args := createMockWSDispatcherArgs()
+	wd, err := ws.NewTestWSDispatcher(args)
+	require.Nil(t, err)
+
+	txs := map[string]data.TransactionWithOrder{
+		"txHash1": {
+			Transaction: transaction.Transaction{
+				Nonce: 1,
+			},
+			ExecutionOrder: 1,
+		},
+	}
+	blockData := data.BlockTxsWithOrder{
+		Hash:      "hash1",
+		ShardID:   1,
+		TimeStamp: 1234,
+		Txs:       txs,
+	}
+	blockDataBytes, err := json.Marshal(blockData)
+	require.Nil(t, err)
+
+	wd.TxsWithOrderEvent(blockData)
+
+	wsEvent := &data.WSEvent{
+		Type: common.BlockTxsWithOrder,
 		Data: blockDataBytes,
 	}
 	expectedEventBytes, _ := json.Marshal(wsEvent)

--- a/dispatcher/ws/wsDispatcher_test.go
+++ b/dispatcher/ws/wsDispatcher_test.go
@@ -201,7 +201,7 @@ func TestBlockEvents(t *testing.T) {
 	require.Equal(t, expectedEventBytes, eventsData)
 }
 
-func TestTxsWithOrderEvents(t *testing.T) {
+func TestBlockEventsWithOrder(t *testing.T) {
 	t.Parallel()
 
 	args := createMockWSDispatcherArgs()
@@ -216,7 +216,7 @@ func TestTxsWithOrderEvents(t *testing.T) {
 			ExecutionOrder: 1,
 		},
 	}
-	blockData := data.BlockTxsWithOrder{
+	blockData := data.BlockEventsWithOrder{
 		Hash:      "hash1",
 		ShardID:   1,
 		TimeStamp: 1234,
@@ -225,10 +225,10 @@ func TestTxsWithOrderEvents(t *testing.T) {
 	blockDataBytes, err := json.Marshal(blockData)
 	require.Nil(t, err)
 
-	wd.TxsWithOrderEvent(blockData)
+	wd.BlockEventsWithOrder(blockData)
 
 	wsEvent := &data.WSEvent{
-		Type: common.BlockTxsWithOrder,
+		Type: common.BlockEventsWithOrder,
 		Data: blockDataBytes,
 	}
 	expectedEventBytes, _ := json.Marshal(wsEvent)

--- a/facade/interface.go
+++ b/facade/interface.go
@@ -13,6 +13,7 @@ type EventsHandler interface {
 	HandleFinalizedEvents(finalizedBlock data.FinalizedBlock)
 	HandleBlockTxs(blockTxs data.BlockTxs)
 	HandleBlockScrs(blockScrs data.BlockScrs)
+	HandleBlockTxsWithOrder(blockTxs data.BlockTxsWithOrder)
 	IsInterfaceNil() bool
 }
 

--- a/facade/interface.go
+++ b/facade/interface.go
@@ -13,7 +13,7 @@ type EventsHandler interface {
 	HandleFinalizedEvents(finalizedBlock data.FinalizedBlock)
 	HandleBlockTxs(blockTxs data.BlockTxs)
 	HandleBlockScrs(blockScrs data.BlockScrs)
-	HandleBlockTxsWithOrder(blockTxs data.BlockTxsWithOrder)
+	HandleBlockEventsWithOrder(blockTxs data.BlockEventsWithOrder)
 	IsInterfaceNil() bool
 }
 

--- a/facade/notifierFacade.go
+++ b/facade/notifierFacade.go
@@ -87,13 +87,13 @@ func (nf *notifierFacade) HandlePushEventsV2(allEvents data.ArgsSaveBlockData) e
 	}
 	nf.eventsHandler.HandleBlockScrs(scrs)
 
-	txsWithOrder := data.BlockTxsWithOrder{
+	txsWithOrder := data.BlockEventsWithOrder{
 		Hash:      eventsData.Hash,
 		ShardID:   eventsData.Header.GetShardID(),
 		TimeStamp: eventsData.Header.GetTimeStamp(),
 		Txs:       eventsData.TxsWithOrder,
 	}
-	nf.eventsHandler.HandleBlockTxsWithOrder(txsWithOrder)
+	nf.eventsHandler.HandleBlockEventsWithOrder(txsWithOrder)
 
 	return nil
 }

--- a/facade/notifierFacade.go
+++ b/facade/notifierFacade.go
@@ -87,6 +87,14 @@ func (nf *notifierFacade) HandlePushEventsV2(allEvents data.ArgsSaveBlockData) e
 	}
 	nf.eventsHandler.HandleBlockScrs(scrs)
 
+	txsWithOrder := data.BlockTxsWithOrder{
+		Hash:      eventsData.Hash,
+		ShardID:   eventsData.Header.GetShardID(),
+		TimeStamp: eventsData.Header.GetTimeStamp(),
+		Txs:       eventsData.TxsWithOrder,
+	}
+	nf.eventsHandler.HandleBlockTxsWithOrder(txsWithOrder)
+
 	return nil
 }
 

--- a/facade/notifierFacade.go
+++ b/facade/notifierFacade.go
@@ -92,6 +92,8 @@ func (nf *notifierFacade) HandlePushEventsV2(allEvents data.ArgsSaveBlockData) e
 		ShardID:   eventsData.Header.GetShardID(),
 		TimeStamp: eventsData.Header.GetTimeStamp(),
 		Txs:       eventsData.TxsWithOrder,
+		Scrs:      eventsData.ScrsWithOrder,
+		Events:    eventsData.LogEvents,
 	}
 	nf.eventsHandler.HandleBlockEventsWithOrder(txsWithOrder)
 

--- a/facade/notifierFacade_test.go
+++ b/facade/notifierFacade_test.go
@@ -167,14 +167,16 @@ func TestHandlePushEvents(t *testing.T) {
 			Events: logEvents,
 		}
 		expTxsWithOrderData := data.BlockEventsWithOrder{
-			Hash: blockHash,
-			Txs:  txs,
+			Hash:   blockHash,
+			Txs:    txs,
+			Scrs:   scrs,
+			Events: logEvents,
 		}
 
 		pushWasCalled := false
 		txsWasCalled := false
 		scrsWasCalled := false
-		txsWithOrderWasCalled := false
+		blockEventsWithOrderWasCalled := false
 		args.EventsHandler = &mocks.EventsHandlerStub{
 			HandlePushEventsCalled: func(events data.BlockEvents) error {
 				pushWasCalled = true
@@ -190,18 +192,19 @@ func TestHandlePushEvents(t *testing.T) {
 				assert.Equal(t, expScrsData, blockScrs)
 			},
 			HandleBlockEventsWithOrderCalled: func(blockTxs data.BlockEventsWithOrder) {
-				txsWithOrderWasCalled = true
+				blockEventsWithOrderWasCalled = true
 				assert.Equal(t, expTxsWithOrderData, blockTxs)
 			},
 		}
 		args.EventsInterceptor = &mocks.EventsInterceptorStub{
 			ProcessBlockEventsCalled: func(eventsData *data.ArgsSaveBlockData) (*data.InterceptorBlockData, error) {
 				return &data.InterceptorBlockData{
-					Hash:         blockHash,
-					Txs:          expTxs,
-					Scrs:         expScrs,
-					LogEvents:    logEvents,
-					TxsWithOrder: txs,
+					Hash:          blockHash,
+					Txs:           expTxs,
+					Scrs:          expScrs,
+					LogEvents:     logEvents,
+					TxsWithOrder:  txs,
+					ScrsWithOrder: scrs,
 				}, nil
 			},
 		}
@@ -214,7 +217,7 @@ func TestHandlePushEvents(t *testing.T) {
 		assert.True(t, pushWasCalled)
 		assert.True(t, txsWasCalled)
 		assert.True(t, scrsWasCalled)
-		assert.True(t, txsWithOrderWasCalled)
+		assert.True(t, blockEventsWithOrderWasCalled)
 	})
 }
 

--- a/facade/notifierFacade_test.go
+++ b/facade/notifierFacade_test.go
@@ -108,6 +108,7 @@ func TestHandlePushEvents(t *testing.T) {
 				Transaction: transaction.Transaction{
 					Nonce: 1,
 				},
+				ExecutionOrder: 1,
 			},
 		}
 		scrs := map[string]data.SmartContractResultWithOrder{
@@ -165,10 +166,15 @@ func TestHandlePushEvents(t *testing.T) {
 			Hash:   blockHash,
 			Events: logEvents,
 		}
+		expTxsWithOrderData := data.BlockTxsWithOrder{
+			Hash: blockHash,
+			Txs:  txs,
+		}
 
 		pushWasCalled := false
 		txsWasCalled := false
 		scrsWasCalled := false
+		txsWithOrderWasCalled := false
 		args.EventsHandler = &mocks.EventsHandlerStub{
 			HandlePushEventsCalled: func(events data.BlockEvents) error {
 				pushWasCalled = true
@@ -183,14 +189,19 @@ func TestHandlePushEvents(t *testing.T) {
 				scrsWasCalled = true
 				assert.Equal(t, expScrsData, blockScrs)
 			},
+			HandleBlockTxsWithOrderCalled: func(blockTxs data.BlockTxsWithOrder) {
+				txsWithOrderWasCalled = true
+				assert.Equal(t, expTxsWithOrderData, blockTxs)
+			},
 		}
 		args.EventsInterceptor = &mocks.EventsInterceptorStub{
 			ProcessBlockEventsCalled: func(eventsData *data.ArgsSaveBlockData) (*data.InterceptorBlockData, error) {
 				return &data.InterceptorBlockData{
-					Hash:      blockHash,
-					Txs:       expTxs,
-					Scrs:      expScrs,
-					LogEvents: logEvents,
+					Hash:         blockHash,
+					Txs:          expTxs,
+					Scrs:         expScrs,
+					LogEvents:    logEvents,
+					TxsWithOrder: txs,
 				}, nil
 			},
 		}
@@ -203,6 +214,7 @@ func TestHandlePushEvents(t *testing.T) {
 		assert.True(t, pushWasCalled)
 		assert.True(t, txsWasCalled)
 		assert.True(t, scrsWasCalled)
+		assert.True(t, txsWithOrderWasCalled)
 	})
 }
 

--- a/facade/notifierFacade_test.go
+++ b/facade/notifierFacade_test.go
@@ -166,7 +166,7 @@ func TestHandlePushEvents(t *testing.T) {
 			Hash:   blockHash,
 			Events: logEvents,
 		}
-		expTxsWithOrderData := data.BlockTxsWithOrder{
+		expTxsWithOrderData := data.BlockEventsWithOrder{
 			Hash: blockHash,
 			Txs:  txs,
 		}
@@ -189,7 +189,7 @@ func TestHandlePushEvents(t *testing.T) {
 				scrsWasCalled = true
 				assert.Equal(t, expScrsData, blockScrs)
 			},
-			HandleBlockTxsWithOrderCalled: func(blockTxs data.BlockTxsWithOrder) {
+			HandleBlockEventsWithOrderCalled: func(blockTxs data.BlockEventsWithOrder) {
 				txsWithOrderWasCalled = true
 				assert.Equal(t, expTxsWithOrderData, blockTxs)
 			},

--- a/integrationTests/rabbitmq/testNotifierWithRabbitMQ_test.go
+++ b/integrationTests/rabbitmq/testNotifierWithRabbitMQ_test.go
@@ -44,8 +44,8 @@ func TestNotifierWithRabbitMQ(t *testing.T) {
 	assert.Equal(t, 5, responses[http.StatusOK])
 	mutResponses.Unlock()
 
-	assert.Equal(t, 5, len(notifier.RedisClient.GetEntries()))
-	assert.Equal(t, 5, len(notifier.RabbitMQClient.GetEntries()))
+	assert.Equal(t, 6, len(notifier.RedisClient.GetEntries()))
+	assert.Equal(t, 6, len(notifier.RabbitMQClient.GetEntries()))
 }
 
 func pushEventsRequest(webServer *integrationTests.TestWebServer, mutResponses *sync.Mutex, responses map[int]int) {
@@ -57,6 +57,7 @@ func pushEventsRequest(webServer *integrationTests.TestWebServer, mutResponses *
 					Transaction: transaction.Transaction{
 						Nonce: 1,
 					},
+					ExecutionOrder: 1,
 				},
 			},
 			Scrs: map[string]data.SmartContractResultWithOrder{

--- a/integrationTests/testNotifierProxy.go
+++ b/integrationTests/testNotifierProxy.go
@@ -193,8 +193,8 @@ func GetDefaultConfigs() *config.GeneralConfig {
 				Name: "blockscrs",
 				Type: "fanout",
 			},
-			BlockTxsWithOrderExchange: config.RabbitMQExchangeConfig{
-				Name: "blocktxswithorder",
+			BlockEventsExchange: config.RabbitMQExchangeConfig{
+				Name: "blockevents",
 				Type: "fanout",
 			},
 		},

--- a/integrationTests/testNotifierProxy.go
+++ b/integrationTests/testNotifierProxy.go
@@ -112,6 +112,9 @@ func NewTestNotifierWithRabbitMq(cfg *config.GeneralConfig) (*testNotifier, erro
 		Config: cfg.RabbitMQ,
 	}
 	publisher, err := rabbitmq.NewRabbitMqPublisher(publisherArgs)
+	if err != nil {
+		return nil, err
+	}
 
 	argsEventsHandler := process.ArgsEventsHandler{
 		Config:    cfg.ConnectorApi,
@@ -188,6 +191,10 @@ func GetDefaultConfigs() *config.GeneralConfig {
 			},
 			BlockScrsExchange: config.RabbitMQExchangeConfig{
 				Name: "blockscrs",
+				Type: "fanout",
+			},
+			BlockTxsWithOrderExchange: config.RabbitMQExchangeConfig{
+				Name: "blocktxswithorder",
 				Type: "fanout",
 			},
 		},

--- a/integrationTests/websocket/testNotifierWithWebsockets_test.go
+++ b/integrationTests/websocket/testNotifierWithWebsockets_test.go
@@ -522,7 +522,7 @@ func TestNotifierWithWebsockets_AllEvents(t *testing.T) {
 		assert.Fail(t, "timeout when handling websocket events")
 	}
 
-	assert.Equal(t, numEvents, len(notifier.RedisClient.GetEntries()))
+	assert.Equal(t, numEvents+1, len(notifier.RedisClient.GetEntries()))
 }
 
 // waitTimeout returns true if work group waiting timed out

--- a/mocks/dispatcherMock.go
+++ b/mocks/dispatcherMock.go
@@ -48,8 +48,8 @@ func (d *DispatcherMock) FinalizedEvent(event data.FinalizedBlock) {
 func (d *DispatcherMock) TxsEvent(event data.BlockTxs) {
 }
 
-// TxsWithOrderEvent -
-func (d *DispatcherMock) TxsWithOrderEvent(event data.BlockTxsWithOrder) {
+// BlockEventsWithOrder -
+func (d *DispatcherMock) BlockEventsWithOrder(event data.BlockEventsWithOrder) {
 }
 
 // ScrsEvent -

--- a/mocks/dispatcherMock.go
+++ b/mocks/dispatcherMock.go
@@ -48,6 +48,10 @@ func (d *DispatcherMock) FinalizedEvent(event data.FinalizedBlock) {
 func (d *DispatcherMock) TxsEvent(event data.BlockTxs) {
 }
 
+// TxsWithOrderEvent -
+func (d *DispatcherMock) TxsWithOrderEvent(event data.BlockTxsWithOrder) {
+}
+
 // ScrsEvent -
 func (d *DispatcherMock) ScrsEvent(event data.BlockScrs) {
 }

--- a/mocks/dispatcherStub.go
+++ b/mocks/dispatcherStub.go
@@ -7,14 +7,14 @@ import (
 
 // DispatcherStub implements dispatcher EventDispatcher interface
 type DispatcherStub struct {
-	GetIDCalled             func() uuid.UUID
-	PushEventsCalled        func(events []data.Event)
-	BlockEventsCalled       func(event data.BlockEvents)
-	RevertEventCalled       func(event data.RevertBlock)
-	FinalizedEventCalled    func(event data.FinalizedBlock)
-	TxsEventCalled          func(event data.BlockTxs)
-	TxsWithOrderEventCalled func(event data.BlockTxsWithOrder)
-	ScrsEventCalled         func(event data.BlockScrs)
+	GetIDCalled                func() uuid.UUID
+	PushEventsCalled           func(events []data.Event)
+	BlockEventsCalled          func(event data.BlockEvents)
+	RevertEventCalled          func(event data.RevertBlock)
+	FinalizedEventCalled       func(event data.FinalizedBlock)
+	TxsEventCalled             func(event data.BlockTxs)
+	BlockEventsWithOrderCalled func(event data.BlockEventsWithOrder)
+	ScrsEventCalled            func(event data.BlockScrs)
 }
 
 // GetID -
@@ -61,10 +61,10 @@ func (d *DispatcherStub) TxsEvent(event data.BlockTxs) {
 	}
 }
 
-// TxsWithOrderEvent -
-func (d *DispatcherStub) TxsWithOrderEvent(event data.BlockTxsWithOrder) {
-	if d.TxsWithOrderEventCalled != nil {
-		d.TxsWithOrderEventCalled(event)
+// BlockEventsWithOrder -
+func (d *DispatcherStub) BlockEventsWithOrder(event data.BlockEventsWithOrder) {
+	if d.BlockEventsWithOrderCalled != nil {
+		d.BlockEventsWithOrderCalled(event)
 	}
 }
 

--- a/mocks/dispatcherStub.go
+++ b/mocks/dispatcherStub.go
@@ -7,13 +7,14 @@ import (
 
 // DispatcherStub implements dispatcher EventDispatcher interface
 type DispatcherStub struct {
-	GetIDCalled          func() uuid.UUID
-	PushEventsCalled     func(events []data.Event)
-	BlockEventsCalled    func(event data.BlockEvents)
-	RevertEventCalled    func(event data.RevertBlock)
-	FinalizedEventCalled func(event data.FinalizedBlock)
-	TxsEventCalled       func(event data.BlockTxs)
-	ScrsEventCalled      func(event data.BlockScrs)
+	GetIDCalled             func() uuid.UUID
+	PushEventsCalled        func(events []data.Event)
+	BlockEventsCalled       func(event data.BlockEvents)
+	RevertEventCalled       func(event data.RevertBlock)
+	FinalizedEventCalled    func(event data.FinalizedBlock)
+	TxsEventCalled          func(event data.BlockTxs)
+	TxsWithOrderEventCalled func(event data.BlockTxsWithOrder)
+	ScrsEventCalled         func(event data.BlockScrs)
 }
 
 // GetID -
@@ -57,6 +58,13 @@ func (d *DispatcherStub) FinalizedEvent(event data.FinalizedBlock) {
 func (d *DispatcherStub) TxsEvent(event data.BlockTxs) {
 	if d.TxsEventCalled != nil {
 		d.TxsEventCalled(event)
+	}
+}
+
+// TxsWithOrderEvent -
+func (d *DispatcherStub) TxsWithOrderEvent(event data.BlockTxsWithOrder) {
+	if d.TxsWithOrderEventCalled != nil {
+		d.TxsWithOrderEventCalled(event)
 	}
 }
 

--- a/mocks/eventsHandlerStub.go
+++ b/mocks/eventsHandlerStub.go
@@ -4,11 +4,12 @@ import "github.com/ElrondNetwork/notifier-go/data"
 
 // EventsHandlerStub implements EventsHandler interface
 type EventsHandlerStub struct {
-	HandlePushEventsCalled      func(events data.BlockEvents) error
-	HandleRevertEventsCalled    func(revertBlock data.RevertBlock)
-	HandleFinalizedEventsCalled func(finalizedBlock data.FinalizedBlock)
-	HandleBlockTxsCalled        func(blockTxs data.BlockTxs)
-	HandleBlockScrsCalled       func(blockScrs data.BlockScrs)
+	HandlePushEventsCalled        func(events data.BlockEvents) error
+	HandleRevertEventsCalled      func(revertBlock data.RevertBlock)
+	HandleFinalizedEventsCalled   func(finalizedBlock data.FinalizedBlock)
+	HandleBlockTxsCalled          func(blockTxs data.BlockTxs)
+	HandleBlockScrsCalled         func(blockScrs data.BlockScrs)
+	HandleBlockTxsWithOrderCalled func(blockTxs data.BlockTxsWithOrder)
 }
 
 // HandlePushEvents -
@@ -45,6 +46,13 @@ func (e *EventsHandlerStub) HandleBlockTxs(blockTxs data.BlockTxs) {
 func (e *EventsHandlerStub) HandleBlockScrs(blockScrs data.BlockScrs) {
 	if e.HandleBlockScrsCalled != nil {
 		e.HandleBlockScrsCalled(blockScrs)
+	}
+}
+
+// HandleBlockTxsWithOrder -
+func (e *EventsHandlerStub) HandleBlockTxsWithOrder(blockTxs data.BlockTxsWithOrder) {
+	if e.HandleBlockTxsWithOrderCalled != nil {
+		e.HandleBlockTxsWithOrderCalled(blockTxs)
 	}
 }
 

--- a/mocks/eventsHandlerStub.go
+++ b/mocks/eventsHandlerStub.go
@@ -4,12 +4,12 @@ import "github.com/ElrondNetwork/notifier-go/data"
 
 // EventsHandlerStub implements EventsHandler interface
 type EventsHandlerStub struct {
-	HandlePushEventsCalled        func(events data.BlockEvents) error
-	HandleRevertEventsCalled      func(revertBlock data.RevertBlock)
-	HandleFinalizedEventsCalled   func(finalizedBlock data.FinalizedBlock)
-	HandleBlockTxsCalled          func(blockTxs data.BlockTxs)
-	HandleBlockScrsCalled         func(blockScrs data.BlockScrs)
-	HandleBlockTxsWithOrderCalled func(blockTxs data.BlockTxsWithOrder)
+	HandlePushEventsCalled           func(events data.BlockEvents) error
+	HandleRevertEventsCalled         func(revertBlock data.RevertBlock)
+	HandleFinalizedEventsCalled      func(finalizedBlock data.FinalizedBlock)
+	HandleBlockTxsCalled             func(blockTxs data.BlockTxs)
+	HandleBlockScrsCalled            func(blockScrs data.BlockScrs)
+	HandleBlockEventsWithOrderCalled func(blockTxs data.BlockEventsWithOrder)
 }
 
 // HandlePushEvents -
@@ -49,10 +49,10 @@ func (e *EventsHandlerStub) HandleBlockScrs(blockScrs data.BlockScrs) {
 	}
 }
 
-// HandleBlockTxsWithOrder -
-func (e *EventsHandlerStub) HandleBlockTxsWithOrder(blockTxs data.BlockTxsWithOrder) {
-	if e.HandleBlockTxsWithOrderCalled != nil {
-		e.HandleBlockTxsWithOrderCalled(blockTxs)
+// HandleBlockEventsWithOrder -
+func (e *EventsHandlerStub) HandleBlockEventsWithOrder(blockTxs data.BlockEventsWithOrder) {
+	if e.HandleBlockEventsWithOrderCalled != nil {
+		e.HandleBlockEventsWithOrderCalled(blockTxs)
 	}
 }
 

--- a/mocks/hubStub.go
+++ b/mocks/hubStub.go
@@ -7,16 +7,17 @@ import (
 
 // HubStub implements Hub interface
 type HubStub struct {
-	RunCalled                func()
-	BroadcastCalled          func(events data.BlockEvents)
-	BroadcastRevertCalled    func(event data.RevertBlock)
-	BroadcastFinalizedCalled func(event data.FinalizedBlock)
-	BroadcastTxsCalled       func(event data.BlockTxs)
-	BroadcastScrsCalled      func(event data.BlockScrs)
-	RegisterEventCalled      func(event dispatcher.EventDispatcher)
-	UnregisterEventCalled    func(event dispatcher.EventDispatcher)
-	SubscribeCalled          func(event data.SubscribeEvent)
-	CloseCalled              func() error
+	RunCalled                   func()
+	BroadcastCalled             func(events data.BlockEvents)
+	BroadcastRevertCalled       func(event data.RevertBlock)
+	BroadcastFinalizedCalled    func(event data.FinalizedBlock)
+	BroadcastTxsCalled          func(event data.BlockTxs)
+	BroadcastScrsCalled         func(event data.BlockScrs)
+	BroadcastTxsWithOrderCalled func(event data.BlockTxsWithOrder)
+	RegisterEventCalled         func(event dispatcher.EventDispatcher)
+	UnregisterEventCalled       func(event dispatcher.EventDispatcher)
+	SubscribeCalled             func(event data.SubscribeEvent)
+	CloseCalled                 func() error
 }
 
 // Run -
@@ -58,6 +59,13 @@ func (h *HubStub) BroadcastTxs(event data.BlockTxs) {
 func (h *HubStub) BroadcastScrs(event data.BlockScrs) {
 	if h.BroadcastScrsCalled != nil {
 		h.BroadcastScrsCalled(event)
+	}
+}
+
+// BroadcastTxsWithOrder -
+func (h *HubStub) BroadcastTxsWithOrder(event data.BlockTxsWithOrder) {
+	if h.BroadcastTxsWithOrderCalled != nil {
+		h.BroadcastTxsWithOrderCalled(event)
 	}
 }
 

--- a/mocks/hubStub.go
+++ b/mocks/hubStub.go
@@ -7,17 +7,17 @@ import (
 
 // HubStub implements Hub interface
 type HubStub struct {
-	RunCalled                   func()
-	BroadcastCalled             func(events data.BlockEvents)
-	BroadcastRevertCalled       func(event data.RevertBlock)
-	BroadcastFinalizedCalled    func(event data.FinalizedBlock)
-	BroadcastTxsCalled          func(event data.BlockTxs)
-	BroadcastScrsCalled         func(event data.BlockScrs)
-	BroadcastTxsWithOrderCalled func(event data.BlockTxsWithOrder)
-	RegisterEventCalled         func(event dispatcher.EventDispatcher)
-	UnregisterEventCalled       func(event dispatcher.EventDispatcher)
-	SubscribeCalled             func(event data.SubscribeEvent)
-	CloseCalled                 func() error
+	RunCalled                           func()
+	BroadcastCalled                     func(events data.BlockEvents)
+	BroadcastRevertCalled               func(event data.RevertBlock)
+	BroadcastFinalizedCalled            func(event data.FinalizedBlock)
+	BroadcastTxsCalled                  func(event data.BlockTxs)
+	BroadcastScrsCalled                 func(event data.BlockScrs)
+	BroadcastBlockEventsWithOrderCalled func(event data.BlockEventsWithOrder)
+	RegisterEventCalled                 func(event dispatcher.EventDispatcher)
+	UnregisterEventCalled               func(event dispatcher.EventDispatcher)
+	SubscribeCalled                     func(event data.SubscribeEvent)
+	CloseCalled                         func() error
 }
 
 // Run -
@@ -62,10 +62,10 @@ func (h *HubStub) BroadcastScrs(event data.BlockScrs) {
 	}
 }
 
-// BroadcastTxsWithOrder -
-func (h *HubStub) BroadcastTxsWithOrder(event data.BlockTxsWithOrder) {
-	if h.BroadcastTxsWithOrderCalled != nil {
-		h.BroadcastTxsWithOrderCalled(event)
+// BroadcastBlockEventsWithOrder -
+func (h *HubStub) BroadcastBlockEventsWithOrder(event data.BlockEventsWithOrder) {
+	if h.BroadcastBlockEventsWithOrderCalled != nil {
+		h.BroadcastBlockEventsWithOrderCalled(event)
 	}
 }
 

--- a/mocks/publisherStub.go
+++ b/mocks/publisherStub.go
@@ -4,13 +4,13 @@ import "github.com/ElrondNetwork/notifier-go/data"
 
 // PublisherStub implements PublisherService interface
 type PublisherStub struct {
-	RunCalled                   func()
-	BroadcastCalled             func(events data.BlockEvents)
-	BroadcastRevertCalled       func(event data.RevertBlock)
-	BroadcastFinalizedCalled    func(event data.FinalizedBlock)
-	BroadcastTxsCalled          func(event data.BlockTxs)
-	BroadcastScrsCalled         func(event data.BlockScrs)
-	BroadcastTxsWithOrderCalled func(event data.BlockTxsWithOrder)
+	RunCalled                           func()
+	BroadcastCalled                     func(events data.BlockEvents)
+	BroadcastRevertCalled               func(event data.RevertBlock)
+	BroadcastFinalizedCalled            func(event data.FinalizedBlock)
+	BroadcastTxsCalled                  func(event data.BlockTxs)
+	BroadcastScrsCalled                 func(event data.BlockScrs)
+	BroadcastBlockEventsWithOrderCalled func(event data.BlockEventsWithOrder)
 }
 
 // Run -
@@ -55,10 +55,10 @@ func (ps *PublisherStub) BroadcastScrs(event data.BlockScrs) {
 	}
 }
 
-// BroadcastTxsWithOrder -
-func (ps *PublisherStub) BroadcastTxsWithOrder(event data.BlockTxsWithOrder) {
-	if ps.BroadcastTxsWithOrderCalled != nil {
-		ps.BroadcastTxsWithOrderCalled(event)
+// BroadcastBlockEventsWithOrder -
+func (ps *PublisherStub) BroadcastBlockEventsWithOrder(event data.BlockEventsWithOrder) {
+	if ps.BroadcastBlockEventsWithOrderCalled != nil {
+		ps.BroadcastBlockEventsWithOrderCalled(event)
 	}
 }
 

--- a/mocks/publisherStub.go
+++ b/mocks/publisherStub.go
@@ -4,12 +4,13 @@ import "github.com/ElrondNetwork/notifier-go/data"
 
 // PublisherStub implements PublisherService interface
 type PublisherStub struct {
-	RunCalled                func()
-	BroadcastCalled          func(events data.BlockEvents)
-	BroadcastRevertCalled    func(event data.RevertBlock)
-	BroadcastFinalizedCalled func(event data.FinalizedBlock)
-	BroadcastTxsCalled       func(event data.BlockTxs)
-	BroadcastScrsCalled      func(event data.BlockScrs)
+	RunCalled                   func()
+	BroadcastCalled             func(events data.BlockEvents)
+	BroadcastRevertCalled       func(event data.RevertBlock)
+	BroadcastFinalizedCalled    func(event data.FinalizedBlock)
+	BroadcastTxsCalled          func(event data.BlockTxs)
+	BroadcastScrsCalled         func(event data.BlockScrs)
+	BroadcastTxsWithOrderCalled func(event data.BlockTxsWithOrder)
 }
 
 // Run -
@@ -51,6 +52,13 @@ func (ps *PublisherStub) BroadcastTxs(event data.BlockTxs) {
 func (ps *PublisherStub) BroadcastScrs(event data.BlockScrs) {
 	if ps.BroadcastScrsCalled != nil {
 		ps.BroadcastScrsCalled(event)
+	}
+}
+
+// BroadcastTxsWithOrder -
+func (ps *PublisherStub) BroadcastTxsWithOrder(event data.BlockTxsWithOrder) {
+	if ps.BroadcastTxsWithOrderCalled != nil {
+		ps.BroadcastTxsWithOrderCalled(event)
 	}
 }
 

--- a/process/eventsHandler.go
+++ b/process/eventsHandler.go
@@ -238,7 +238,7 @@ func (eh *eventsHandler) HandleBlockScrs(blockScrs data.BlockScrs) {
 // HandleBlockEventsWithOrder will handle full block events received from observer
 func (eh *eventsHandler) HandleBlockEventsWithOrder(blockTxs data.BlockEventsWithOrder) {
 	if blockTxs.Hash == "" {
-		log.Warn("received empty full block events with order block hash",
+		log.Warn("received full block events with empty block hash",
 			"will process", false,
 		)
 		return

--- a/process/eventsHandler.go
+++ b/process/eventsHandler.go
@@ -235,10 +235,10 @@ func (eh *eventsHandler) HandleBlockScrs(blockScrs data.BlockScrs) {
 	eh.publisher.BroadcastScrs(blockScrs)
 }
 
-// HandleBlockTxsWithOrder will handle txs events received from observer
-func (eh *eventsHandler) HandleBlockTxsWithOrder(blockTxs data.BlockTxsWithOrder) {
+// HandleBlockEventsWithOrder will handle full block events received from observer
+func (eh *eventsHandler) HandleBlockEventsWithOrder(blockTxs data.BlockEventsWithOrder) {
 	if blockTxs.Hash == "" {
-		log.Warn("received empty txs with order block hash",
+		log.Warn("received empty full block events with order block hash",
 			"will process", false,
 		)
 		return
@@ -250,7 +250,7 @@ func (eh *eventsHandler) HandleBlockTxsWithOrder(blockTxs data.BlockTxsWithOrder
 	}
 
 	if !shouldProcessTxs {
-		log.Info("received duplicated txs event for block",
+		log.Info("received duplicated full block events for block",
 			"block hash", blockTxs.Hash,
 			"processed", false,
 		)
@@ -269,7 +269,7 @@ func (eh *eventsHandler) HandleBlockTxsWithOrder(blockTxs data.BlockTxsWithOrder
 		)
 	}
 
-	eh.publisher.BroadcastTxsWithOrder(blockTxs)
+	eh.publisher.BroadcastBlockEventsWithOrder(blockTxs)
 }
 
 func (eh *eventsHandler) tryCheckProcessedWithRetry(blockHash string) bool {

--- a/process/eventsHandler_test.go
+++ b/process/eventsHandler_test.go
@@ -365,10 +365,10 @@ func TestHandleScrsEvents(t *testing.T) {
 	})
 }
 
-func TestHandleTxsWithOrderEvents(t *testing.T) {
+func TestHandleBlockEventsWithOrderEvents(t *testing.T) {
 	t.Parallel()
 
-	events := data.BlockTxsWithOrder{
+	events := data.BlockEventsWithOrder{
 		Hash: "hash1",
 		Txs: map[string]data.TransactionWithOrder{
 			"hash1": {
@@ -380,13 +380,13 @@ func TestHandleTxsWithOrderEvents(t *testing.T) {
 		},
 	}
 
-	t.Run("broadcast txs with order event was called", func(t *testing.T) {
+	t.Run("broadcast block events with order event was called", func(t *testing.T) {
 		t.Parallel()
 
 		wasCalled := false
 		args := createMockEventsHandlerArgs()
 		args.Publisher = &mocks.PublisherStub{
-			BroadcastTxsWithOrderCalled: func(event data.BlockTxsWithOrder) {
+			BroadcastBlockEventsWithOrderCalled: func(event data.BlockEventsWithOrder) {
 				require.Equal(t, events, events)
 				wasCalled = true
 			},
@@ -395,7 +395,7 @@ func TestHandleTxsWithOrderEvents(t *testing.T) {
 		eventsHandler, err := process.NewEventsHandler(args)
 		require.Nil(t, err)
 
-		eventsHandler.HandleBlockTxsWithOrder(events)
+		eventsHandler.HandleBlockEventsWithOrder(events)
 		require.True(t, wasCalled)
 	})
 
@@ -406,7 +406,7 @@ func TestHandleTxsWithOrderEvents(t *testing.T) {
 		args := createMockEventsHandlerArgs()
 		args.Config.CheckDuplicates = true
 		args.Publisher = &mocks.PublisherStub{
-			BroadcastTxsWithOrderCalled: func(event data.BlockTxsWithOrder) {
+			BroadcastBlockEventsWithOrderCalled: func(event data.BlockEventsWithOrder) {
 				require.Equal(t, events, events)
 				wasCalled = true
 			},
@@ -420,7 +420,7 @@ func TestHandleTxsWithOrderEvents(t *testing.T) {
 		eventsHandler, err := process.NewEventsHandler(args)
 		require.Nil(t, err)
 
-		eventsHandler.HandleBlockTxsWithOrder(events)
+		eventsHandler.HandleBlockEventsWithOrder(events)
 		require.False(t, wasCalled)
 	})
 }

--- a/process/eventsHandler_test.go
+++ b/process/eventsHandler_test.go
@@ -365,6 +365,66 @@ func TestHandleScrsEvents(t *testing.T) {
 	})
 }
 
+func TestHandleTxsWithOrderEvents(t *testing.T) {
+	t.Parallel()
+
+	events := data.BlockTxsWithOrder{
+		Hash: "hash1",
+		Txs: map[string]data.TransactionWithOrder{
+			"hash1": {
+				Transaction: transaction.Transaction{
+					Nonce: 1,
+				},
+				ExecutionOrder: 2,
+			},
+		},
+	}
+
+	t.Run("broadcast txs with order event was called", func(t *testing.T) {
+		t.Parallel()
+
+		wasCalled := false
+		args := createMockEventsHandlerArgs()
+		args.Publisher = &mocks.PublisherStub{
+			BroadcastTxsWithOrderCalled: func(event data.BlockTxsWithOrder) {
+				require.Equal(t, events, events)
+				wasCalled = true
+			},
+		}
+
+		eventsHandler, err := process.NewEventsHandler(args)
+		require.Nil(t, err)
+
+		eventsHandler.HandleBlockTxsWithOrder(events)
+		require.True(t, wasCalled)
+	})
+
+	t.Run("check duplicates enabled, should not process event", func(t *testing.T) {
+		t.Parallel()
+
+		wasCalled := false
+		args := createMockEventsHandlerArgs()
+		args.Config.CheckDuplicates = true
+		args.Publisher = &mocks.PublisherStub{
+			BroadcastTxsWithOrderCalled: func(event data.BlockTxsWithOrder) {
+				require.Equal(t, events, events)
+				wasCalled = true
+			},
+		}
+		args.Locker = &mocks.LockerStub{
+			IsEventProcessedCalled: func(ctx context.Context, blockHash string) (bool, error) {
+				return false, nil
+			},
+		}
+
+		eventsHandler, err := process.NewEventsHandler(args)
+		require.Nil(t, err)
+
+		eventsHandler.HandleBlockTxsWithOrder(events)
+		require.False(t, wasCalled)
+	})
+}
+
 func TestTryCheckProcessedWithRetry(t *testing.T) {
 	t.Parallel()
 

--- a/process/eventsInterceptor.go
+++ b/process/eventsInterceptor.go
@@ -58,13 +58,14 @@ func (ei *eventsInterceptor) ProcessBlockEvents(eventsData *data.ArgsSaveBlockDa
 	}
 
 	return &data.InterceptorBlockData{
-		Hash:         hex.EncodeToString(eventsData.HeaderHash),
-		Body:         eventsData.Body,
-		Header:       eventsData.Header,
-		Txs:          txs,
-		TxsWithOrder: eventsData.TransactionsPool.Txs,
-		Scrs:         scrs,
-		LogEvents:    events,
+		Hash:          hex.EncodeToString(eventsData.HeaderHash),
+		Body:          eventsData.Body,
+		Header:        eventsData.Header,
+		Txs:           txs,
+		TxsWithOrder:  eventsData.TransactionsPool.Txs,
+		Scrs:          scrs,
+		ScrsWithOrder: eventsData.TransactionsPool.Scrs,
+		LogEvents:     events,
 	}, nil
 }
 

--- a/process/eventsInterceptor.go
+++ b/process/eventsInterceptor.go
@@ -58,12 +58,13 @@ func (ei *eventsInterceptor) ProcessBlockEvents(eventsData *data.ArgsSaveBlockDa
 	}
 
 	return &data.InterceptorBlockData{
-		Hash:      hex.EncodeToString(eventsData.HeaderHash),
-		Body:      eventsData.Body,
-		Header:    eventsData.Header,
-		Txs:       txs,
-		Scrs:      scrs,
-		LogEvents: events,
+		Hash:         hex.EncodeToString(eventsData.HeaderHash),
+		Body:         eventsData.Body,
+		Header:       eventsData.Header,
+		Txs:          txs,
+		TxsWithOrder: eventsData.TransactionsPool.Txs,
+		Scrs:         scrs,
+		LogEvents:    events,
 	}, nil
 }
 

--- a/process/eventsInterceptor_test.go
+++ b/process/eventsInterceptor_test.go
@@ -160,14 +160,6 @@ func TestProcessBlockEvents(t *testing.T) {
 				Nonce: 2,
 			},
 		}
-		expTxsWithOrder := map[string]data.TransactionWithOrder{
-			"hash2": {
-				ExecutionOrder: 1,
-				Transaction: transaction.Transaction{
-					Nonce: 2,
-				},
-			},
-		}
 		expScrs := map[string]smartContractResult.SmartContractResult{
 			"hash3": {
 				Nonce: 3,
@@ -175,12 +167,13 @@ func TestProcessBlockEvents(t *testing.T) {
 		}
 
 		expEvents := &data.InterceptorBlockData{
-			Hash:         hex.EncodeToString(blockHash),
-			Body:         blockBody,
-			Header:       blockHeader,
-			Txs:          expTxs,
-			TxsWithOrder: expTxsWithOrder,
-			Scrs:         expScrs,
+			Hash:          hex.EncodeToString(blockHash),
+			Body:          blockBody,
+			Header:        blockHeader,
+			Txs:           expTxs,
+			TxsWithOrder:  txs,
+			Scrs:          expScrs,
+			ScrsWithOrder: scrs,
 			LogEvents: []data.Event{
 				{
 					Address: hex.EncodeToString(addr),

--- a/process/eventsInterceptor_test.go
+++ b/process/eventsInterceptor_test.go
@@ -160,6 +160,14 @@ func TestProcessBlockEvents(t *testing.T) {
 				Nonce: 2,
 			},
 		}
+		expTxsWithOrder := map[string]data.TransactionWithOrder{
+			"hash2": {
+				ExecutionOrder: 1,
+				Transaction: transaction.Transaction{
+					Nonce: 2,
+				},
+			},
+		}
 		expScrs := map[string]smartContractResult.SmartContractResult{
 			"hash3": {
 				Nonce: 3,
@@ -167,11 +175,12 @@ func TestProcessBlockEvents(t *testing.T) {
 		}
 
 		expEvents := &data.InterceptorBlockData{
-			Hash:   hex.EncodeToString(blockHash),
-			Body:   blockBody,
-			Header: blockHeader,
-			Txs:    expTxs,
-			Scrs:   expScrs,
+			Hash:         hex.EncodeToString(blockHash),
+			Body:         blockBody,
+			Header:       blockHeader,
+			Txs:          expTxs,
+			TxsWithOrder: expTxsWithOrder,
+			Scrs:         expScrs,
 			LogEvents: []data.Event{
 				{
 					Address: hex.EncodeToString(addr),

--- a/process/interface.go
+++ b/process/interface.go
@@ -21,6 +21,7 @@ type Publisher interface {
 	BroadcastRevert(event data.RevertBlock)
 	BroadcastFinalized(event data.FinalizedBlock)
 	BroadcastTxs(event data.BlockTxs)
+	BroadcastTxsWithOrder(event data.BlockTxsWithOrder)
 	BroadcastScrs(event data.BlockScrs)
 	IsInterfaceNil() bool
 }
@@ -32,6 +33,7 @@ type EventsHandler interface {
 	HandleFinalizedEvents(finalizedBlock data.FinalizedBlock)
 	HandleBlockTxs(blockTxs data.BlockTxs)
 	HandleBlockScrs(blockScrs data.BlockScrs)
+	HandleBlockTxsWithOrder(blockTxs data.BlockTxsWithOrder)
 	IsInterfaceNil() bool
 }
 

--- a/process/interface.go
+++ b/process/interface.go
@@ -21,7 +21,7 @@ type Publisher interface {
 	BroadcastRevert(event data.RevertBlock)
 	BroadcastFinalized(event data.FinalizedBlock)
 	BroadcastTxs(event data.BlockTxs)
-	BroadcastTxsWithOrder(event data.BlockTxsWithOrder)
+	BroadcastBlockEventsWithOrder(event data.BlockEventsWithOrder)
 	BroadcastScrs(event data.BlockScrs)
 	IsInterfaceNil() bool
 }
@@ -33,7 +33,7 @@ type EventsHandler interface {
 	HandleFinalizedEvents(finalizedBlock data.FinalizedBlock)
 	HandleBlockTxs(blockTxs data.BlockTxs)
 	HandleBlockScrs(blockScrs data.BlockScrs)
-	HandleBlockTxsWithOrder(blockTxs data.BlockTxsWithOrder)
+	HandleBlockEventsWithOrder(blockTxs data.BlockEventsWithOrder)
 	IsInterfaceNil() bool
 }
 

--- a/rabbitmq/interface.go
+++ b/rabbitmq/interface.go
@@ -26,6 +26,7 @@ type PublisherService interface {
 	BroadcastFinalized(event data.FinalizedBlock)
 	BroadcastTxs(event data.BlockTxs)
 	BroadcastScrs(event data.BlockScrs)
+	BroadcastTxsWithOrder(event data.BlockTxsWithOrder)
 	Close() error
 	IsInterfaceNil() bool
 }

--- a/rabbitmq/interface.go
+++ b/rabbitmq/interface.go
@@ -26,7 +26,7 @@ type PublisherService interface {
 	BroadcastFinalized(event data.FinalizedBlock)
 	BroadcastTxs(event data.BlockTxs)
 	BroadcastScrs(event data.BlockScrs)
-	BroadcastTxsWithOrder(event data.BlockTxsWithOrder)
+	BroadcastBlockEventsWithOrder(event data.BlockEventsWithOrder)
 	Close() error
 	IsInterfaceNil() bool
 }

--- a/rabbitmq/publisher.go
+++ b/rabbitmq/publisher.go
@@ -46,14 +46,15 @@ func NewRabbitMqPublisher(args ArgsRabbitMqPublisher) (*rabbitMqPublisher, error
 	}
 
 	rp := &rabbitMqPublisher{
-		broadcast:          make(chan data.BlockEvents),
-		broadcastRevert:    make(chan data.RevertBlock),
-		broadcastFinalized: make(chan data.FinalizedBlock),
-		broadcastTxs:       make(chan data.BlockTxs),
-		broadcastScrs:      make(chan data.BlockScrs),
-		cfg:                args.Config,
-		client:             args.Client,
-		closeChan:          make(chan struct{}),
+		broadcast:             make(chan data.BlockEvents),
+		broadcastRevert:       make(chan data.RevertBlock),
+		broadcastFinalized:    make(chan data.FinalizedBlock),
+		broadcastTxs:          make(chan data.BlockTxs),
+		broadcastScrs:         make(chan data.BlockScrs),
+		broadcastTxsWithOrder: make(chan data.BlockTxsWithOrder),
+		cfg:                   args.Config,
+		client:                args.Client,
+		closeChan:             make(chan struct{}),
 	}
 
 	err = rp.createExchanges()

--- a/rabbitmq/publisher.go
+++ b/rabbitmq/publisher.go
@@ -100,6 +100,12 @@ func checkArgs(args ArgsRabbitMqPublisher) error {
 	if args.Config.BlockScrsExchange.Type == "" {
 		return ErrInvalidRabbitMqExchangeType
 	}
+	if args.Config.BlockTxsWithOrderExchange.Name == "" {
+		return ErrInvalidRabbitMqExchangeName
+	}
+	if args.Config.BlockTxsWithOrderExchange.Type == "" {
+		return ErrInvalidRabbitMqExchangeType
+	}
 
 	return nil
 }

--- a/rabbitmq/publisher.go
+++ b/rabbitmq/publisher.go
@@ -27,12 +27,12 @@ type rabbitMqPublisher struct {
 	client RabbitMqClient
 	cfg    config.RabbitMQConfig
 
-	broadcast             chan data.BlockEvents
-	broadcastRevert       chan data.RevertBlock
-	broadcastFinalized    chan data.FinalizedBlock
-	broadcastTxs          chan data.BlockTxs
-	broadcastTxsWithOrder chan data.BlockTxsWithOrder
-	broadcastScrs         chan data.BlockScrs
+	broadcast                     chan data.BlockEvents
+	broadcastRevert               chan data.RevertBlock
+	broadcastFinalized            chan data.FinalizedBlock
+	broadcastTxs                  chan data.BlockTxs
+	broadcastBlockEventsWithOrder chan data.BlockEventsWithOrder
+	broadcastScrs                 chan data.BlockScrs
 
 	cancelFunc func()
 	closeChan  chan struct{}
@@ -46,15 +46,15 @@ func NewRabbitMqPublisher(args ArgsRabbitMqPublisher) (*rabbitMqPublisher, error
 	}
 
 	rp := &rabbitMqPublisher{
-		broadcast:             make(chan data.BlockEvents),
-		broadcastRevert:       make(chan data.RevertBlock),
-		broadcastFinalized:    make(chan data.FinalizedBlock),
-		broadcastTxs:          make(chan data.BlockTxs),
-		broadcastScrs:         make(chan data.BlockScrs),
-		broadcastTxsWithOrder: make(chan data.BlockTxsWithOrder),
-		cfg:                   args.Config,
-		client:                args.Client,
-		closeChan:             make(chan struct{}),
+		broadcast:                     make(chan data.BlockEvents),
+		broadcastRevert:               make(chan data.RevertBlock),
+		broadcastFinalized:            make(chan data.FinalizedBlock),
+		broadcastTxs:                  make(chan data.BlockTxs),
+		broadcastScrs:                 make(chan data.BlockScrs),
+		broadcastBlockEventsWithOrder: make(chan data.BlockEventsWithOrder),
+		cfg:                           args.Config,
+		client:                        args.Client,
+		closeChan:                     make(chan struct{}),
 	}
 
 	err = rp.createExchanges()
@@ -100,10 +100,10 @@ func checkArgs(args ArgsRabbitMqPublisher) error {
 	if args.Config.BlockScrsExchange.Type == "" {
 		return ErrInvalidRabbitMqExchangeType
 	}
-	if args.Config.BlockTxsWithOrderExchange.Name == "" {
+	if args.Config.BlockEventsExchange.Name == "" {
 		return ErrInvalidRabbitMqExchangeName
 	}
-	if args.Config.BlockTxsWithOrderExchange.Type == "" {
+	if args.Config.BlockEventsExchange.Type == "" {
 		return ErrInvalidRabbitMqExchangeType
 	}
 
@@ -132,7 +132,7 @@ func (rp *rabbitMqPublisher) createExchanges() error {
 	if err != nil {
 		return err
 	}
-	err = rp.createExchange(rp.cfg.BlockTxsWithOrderExchange)
+	err = rp.createExchange(rp.cfg.BlockEventsExchange)
 	if err != nil {
 		return err
 	}
@@ -175,8 +175,8 @@ func (rp *rabbitMqPublisher) run(ctx context.Context) {
 			rp.publishTxsToExchange(blockTxs)
 		case blockScrs := <-rp.broadcastScrs:
 			rp.publishScrsToExchange(blockScrs)
-		case blockTxs := <-rp.broadcastTxsWithOrder:
-			rp.publishTxsWithOrderToExchange(blockTxs)
+		case blockEvents := <-rp.broadcastBlockEventsWithOrder:
+			rp.publishBlockEventsWithOrderToExchange(blockEvents)
 		case err := <-rp.client.ConnErrChan():
 			if err != nil {
 				log.Error("rabbitMQ connection failure", "err", err.Error())
@@ -231,10 +231,10 @@ func (rp *rabbitMqPublisher) BroadcastScrs(events data.BlockScrs) {
 	}
 }
 
-// BroadcastTxsWithOrder will handle the txs event pushed by producers and sends them to rabbitMQ channel
-func (rp *rabbitMqPublisher) BroadcastTxsWithOrder(events data.BlockTxsWithOrder) {
+// BroadcastBlockEventsWithOrder will handle the full block events pushed by producers and sends them to rabbitMQ channel
+func (rp *rabbitMqPublisher) BroadcastBlockEventsWithOrder(events data.BlockEventsWithOrder) {
 	select {
-	case rp.broadcastTxsWithOrder <- events:
+	case rp.broadcastBlockEventsWithOrder <- events:
 	case <-rp.closeChan:
 	}
 }
@@ -304,16 +304,16 @@ func (rp *rabbitMqPublisher) publishScrsToExchange(blockScrs data.BlockScrs) {
 	}
 }
 
-func (rp *rabbitMqPublisher) publishTxsWithOrderToExchange(blockTxs data.BlockTxsWithOrder) {
+func (rp *rabbitMqPublisher) publishBlockEventsWithOrderToExchange(blockTxs data.BlockEventsWithOrder) {
 	txsBlockBytes, err := json.Marshal(blockTxs)
 	if err != nil {
 		log.Error("could not marshal block txs event", "err", err.Error())
 		return
 	}
 
-	err = rp.publishFanout(rp.cfg.BlockTxsWithOrderExchange.Name, txsBlockBytes)
+	err = rp.publishFanout(rp.cfg.BlockEventsExchange.Name, txsBlockBytes)
 	if err != nil {
-		log.Error("failed to publish block txs with order event to rabbitMQ", "err", err.Error())
+		log.Error("failed to publish full block events to rabbitMQ", "err", err.Error())
 	}
 }
 

--- a/rabbitmq/publisher_test.go
+++ b/rabbitmq/publisher_test.go
@@ -41,8 +41,8 @@ func createMockArgsRabbitMqPublisher() rabbitmq.ArgsRabbitMqPublisher {
 				Name: "blockscrs",
 				Type: "fanout",
 			},
-			BlockTxsWithOrderExchange: config.RabbitMQExchangeConfig{
-				Name: "blocktxswithorder",
+			BlockEventsExchange: config.RabbitMQExchangeConfig{
+				Name: "blockeventswithorder",
 				Type: "fanout",
 			},
 		},
@@ -321,7 +321,7 @@ func TestBroadcastScrs(t *testing.T) {
 	assert.Equal(t, uint32(1), atomic.LoadUint32(&numCalls))
 }
 
-func TestBroadcastTxsWithOrder(t *testing.T) {
+func TestBroadcastBlockEventsWithOrder(t *testing.T) {
 	t.Parallel()
 
 	numCalls := uint32(0)
@@ -342,7 +342,7 @@ func TestBroadcastTxsWithOrder(t *testing.T) {
 	rabbitmq.Run()
 	defer rabbitmq.Close()
 
-	rabbitmq.BroadcastTxsWithOrder(data.BlockTxsWithOrder{})
+	rabbitmq.BroadcastBlockEventsWithOrder(data.BlockEventsWithOrder{})
 
 	time.Sleep(time.Millisecond * 200)
 


### PR DESCRIPTION
Added separate rabbitmq exchange for full block events, including txs with order; updated also for websocket dispatcher.
The separate channel was added (instead of updating the existing one) in order to keep the backwards compatibility.