### PR TITLE
fix revert data type

### DIFF
--- a/integrationTests/interface.go
+++ b/integrationTests/interface.go
@@ -18,7 +18,7 @@ type PublisherHandler interface {
 // ObserverConnector defines the observer connector behaviour
 type ObserverConnector interface {
 	PushEventsRequest(events *outport.OutportBlock) error
-	RevertEventsRequest(events *outport.BlockData) error
+	RevertEventsRequest(events *data.RevertBlock) error
 	FinalizedEventsRequest(events *outport.FinalizedBlock) error
 	Close() error
 }

--- a/integrationTests/rabbitmq/testNotifierWithRabbitMQ_test.go
+++ b/integrationTests/rabbitmq/testNotifierWithRabbitMQ_test.go
@@ -1,6 +1,7 @@
 package rabbitmq
 
 import (
+	"encoding/hex"
 	"encoding/json"
 	"sync"
 	"testing"
@@ -13,6 +14,7 @@ import (
 	"github.com/multiversx/mx-chain-core-go/data/transaction"
 	logger "github.com/multiversx/mx-chain-logger-go"
 	"github.com/multiversx/mx-chain-notifier-go/common"
+	"github.com/multiversx/mx-chain-notifier-go/data"
 	"github.com/multiversx/mx-chain-notifier-go/integrationTests"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -108,7 +110,7 @@ func pushEventsRequest(wg *sync.WaitGroup, webServer integrationTests.ObserverCo
 			HeaderHash:  []byte("headerHash1"),
 			Body: &block.Body{
 				MiniBlocks: []*block.MiniBlock{
-					&block.MiniBlock{},
+					{},
 				},
 			},
 		},
@@ -125,18 +127,13 @@ func pushEventsRequest(wg *sync.WaitGroup, webServer integrationTests.ObserverCo
 }
 
 func pushRevertRequest(wg *sync.WaitGroup, webServer integrationTests.ObserverConnector) {
-	header := &block.HeaderV2{
-		Header: &block.Header{
-			Nonce: 1,
-		},
+	revertData := &data.RevertBlock{
+		Hash:  hex.EncodeToString([]byte("headerHash2")),
+		Nonce: 1,
+		Round: 1,
+		Epoch: 1,
 	}
-	headerBytes, _ := json.Marshal(header)
-	blockData := &outport.BlockData{
-		HeaderBytes: headerBytes,
-		HeaderType:  string(core.ShardHeaderV2),
-		HeaderHash:  []byte("headerHash2"),
-	}
-	err := webServer.RevertEventsRequest(blockData)
+	err := webServer.RevertEventsRequest(revertData)
 	log.LogIfError(err)
 
 	if err == nil {

--- a/integrationTests/testObserverConnector.go
+++ b/integrationTests/testObserverConnector.go
@@ -15,6 +15,7 @@ import (
 	"github.com/multiversx/mx-chain-notifier-go/api/shared"
 	"github.com/multiversx/mx-chain-notifier-go/common"
 	"github.com/multiversx/mx-chain-notifier-go/config"
+	"github.com/multiversx/mx-chain-notifier-go/data"
 	"github.com/multiversx/mx-chain-notifier-go/factory"
 	"github.com/multiversx/mx-chain-notifier-go/process"
 )
@@ -121,17 +122,17 @@ func newWSObsClient(marshaller marshal.Marshalizer, url string) (*wsObsClient, e
 	}, nil
 }
 
-// SaveBlock will handle the saving of block
+// PushEventsRequest will handle the saving of block
 func (o *wsObsClient) PushEventsRequest(outportBlock *outport.OutportBlock) error {
 	return o.handleAction(outportBlock, outport.TopicSaveBlock)
 }
 
-// RevertIndexedBlock will handle the action of reverting the indexed block
-func (o *wsObsClient) RevertEventsRequest(blockData *outport.BlockData) error {
-	return o.handleAction(blockData, outport.TopicRevertIndexedBlock)
+// RevertEventsRequest will handle the action of reverting the indexed block
+func (o *wsObsClient) RevertEventsRequest(revertData *data.RevertBlock) error {
+	return o.handleAction(revertData, outport.TopicRevertIndexedBlock)
 }
 
-// FinalizedBlock will handle the finalized block
+// FinalizedEventsRequest will handle the finalized block
 func (o *wsObsClient) FinalizedEventsRequest(finalizedBlock *outport.FinalizedBlock) error {
 	return o.handleAction(finalizedBlock, outport.TopicFinalizedBlock)
 }

--- a/integrationTests/testWebServer.go
+++ b/integrationTests/testWebServer.go
@@ -20,6 +20,7 @@ import (
 	"github.com/multiversx/mx-chain-notifier-go/api/shared"
 	"github.com/multiversx/mx-chain-notifier-go/common"
 	"github.com/multiversx/mx-chain-notifier-go/config"
+	"github.com/multiversx/mx-chain-notifier-go/data"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -107,8 +108,8 @@ func (w *TestWebServer) PushEventsRequest(events *outport.OutportBlock) error {
 }
 
 // RevertEventsRequest will send a http request for revert event
-func (w *TestWebServer) RevertEventsRequest(events *outport.BlockData) error {
-	jsonBytes, _ := json.Marshal(events)
+func (w *TestWebServer) RevertEventsRequest(revertData *data.RevertBlock) error {
+	jsonBytes, _ := json.Marshal(revertData)
 
 	req, _ := http.NewRequest("POST", "/events/revert", bytes.NewBuffer(jsonBytes))
 	req.Header.Set("Content-Type", "application/json")

--- a/integrationTests/websocket/testNotifierWithWebsockets_test.go
+++ b/integrationTests/websocket/testNotifierWithWebsockets_test.go
@@ -219,18 +219,11 @@ func TestNotifierWithWebsockets_RevertEvents(t *testing.T) {
 		},
 	}
 
-	ws.SendSubscribeMessage(subscribeEvent)
+	_ = ws.SendSubscribeMessage(subscribeEvent)
 
-	header := &block.HeaderV2{
-		Header: &block.Header{
-			Nonce: 1,
-		},
-	}
-	headerBytes, _ := json.Marshal(header)
-	blockEvents := &outport.BlockData{
-		HeaderBytes: headerBytes,
-		HeaderType:  string(core.ShardHeaderV2),
-		HeaderHash:  []byte("hash1"),
+	revertBlock := &data.RevertBlock{
+		Hash:  hex.EncodeToString([]byte("hash1")),
+		Nonce: 1,
 	}
 
 	expReply := &data.RevertBlock{
@@ -251,7 +244,7 @@ func TestNotifierWithWebsockets_RevertEvents(t *testing.T) {
 
 	time.Sleep(time.Second)
 
-	err = webServer.RevertEventsRequest(blockEvents)
+	err = webServer.RevertEventsRequest(revertBlock)
 	require.Nil(t, err)
 
 	integrationTests.WaitTimeout(t, wg, time.Second*2)
@@ -533,15 +526,9 @@ func testNotifierWithWebsockets_AllEvents(t *testing.T, observerType string) {
 		},
 	}
 	headerBytes, _ := json.Marshal(header)
-	revertBlock := &outport.BlockData{
-		HeaderBytes: headerBytes,
-		HeaderType:  string(core.ShardHeaderV2),
-		HeaderHash:  []byte("hash1"),
-		Body: &block.Body{
-			MiniBlocks: []*block.MiniBlock{
-				&block.MiniBlock{},
-			},
-		},
+	revertData := &data.RevertBlock{
+		Hash:  hex.EncodeToString([]byte("hash1")),
+		Nonce: 1,
 	}
 	expRevertBlock := &data.RevertBlock{
 		Hash:  hex.EncodeToString([]byte("hash1")),
@@ -711,7 +698,7 @@ func testNotifierWithWebsockets_AllEvents(t *testing.T, observerType string) {
 
 	go client.PushEventsRequest(blockEvents)
 	go client.FinalizedEventsRequest(finalizedBlock)
-	go client.RevertEventsRequest(revertBlock)
+	go client.RevertEventsRequest(revertData)
 
 	integrationTests.WaitTimeout(t, wg, time.Second*4)
 

--- a/mocks/eventsDataProcessorStub.go
+++ b/mocks/eventsDataProcessorStub.go
@@ -1,11 +1,14 @@
 package mocks
 
-import "github.com/multiversx/mx-chain-core-go/data/outport"
+import (
+	"github.com/multiversx/mx-chain-core-go/data/outport"
+	"github.com/multiversx/mx-chain-notifier-go/data"
+)
 
 // EventsDataProcessorStub -
 type EventsDataProcessorStub struct {
 	SaveBlockCalled          func(outportBlock *outport.OutportBlock) error
-	RevertIndexedBlockCalled func(blockData *outport.BlockData) error
+	RevertIndexedBlockCalled func(blockData *data.RevertBlock) error
 	FinalizedBlockCalled     func(finalizedBlock *outport.FinalizedBlock) error
 }
 
@@ -19,7 +22,7 @@ func (stub *EventsDataProcessorStub) SaveBlock(outportBlock *outport.OutportBloc
 }
 
 // RevertIndexedBlock -
-func (stub *EventsDataProcessorStub) RevertIndexedBlock(blockData *outport.BlockData) error {
+func (stub *EventsDataProcessorStub) RevertIndexedBlock(blockData *data.RevertBlock) error {
 	if stub.RevertIndexedBlockCalled != nil {
 		return stub.RevertIndexedBlockCalled(blockData)
 	}

--- a/process/dataPreProcessor.go
+++ b/process/dataPreProcessor.go
@@ -127,19 +127,7 @@ func checkBlockDataValid(block *outport.OutportBlock) error {
 }
 
 // RevertIndexedBlock will handle the revert block event
-func (d *eventsDataPreProcessor) RevertIndexedBlock(blockData *outport.BlockData) error {
-	header, err := d.getHeaderFromBytes(core.HeaderType(blockData.HeaderType), blockData.HeaderBytes)
-	if err != nil {
-		return err
-	}
-
-	revertData := &data.RevertBlock{
-		Hash:  hex.EncodeToString(blockData.GetHeaderHash()),
-		Nonce: header.GetNonce(),
-		Round: header.GetRound(),
-		Epoch: header.GetEpoch(),
-	}
-
+func (d *eventsDataPreProcessor) RevertIndexedBlock(revertData *data.RevertBlock) error {
 	d.facade.HandleRevertEvents(*revertData)
 
 	return nil

--- a/process/dataPreProcessor_test.go
+++ b/process/dataPreProcessor_test.go
@@ -152,43 +152,18 @@ func TestSaveBlock(t *testing.T) {
 func TestRevertIndexerBlock(t *testing.T) {
 	t.Parallel()
 
-	t.Run("failed to get header from bytes, invalid header type", func(t *testing.T) {
-		t.Parallel()
-
-		b := &block.Header{
-			Nonce: 1,
-		}
-		blockBytes, _ := json.Marshal(b)
-
-		blockData := &outport.BlockData{
-			HeaderBytes: blockBytes,
-			HeaderType:  "invalid",
-		}
-
-		dp, err := process.NewEventsDataPreProcessor(createMockEventsDataPreProcessorArgs())
-		require.Nil(t, err)
-
-		err = dp.RevertIndexedBlock(blockData)
-		require.Equal(t, coreData.ErrInvalidHeaderType, err)
-	})
-
 	t.Run("should work", func(t *testing.T) {
 		t.Parallel()
 
-		b := &block.Header{
-			Nonce: 1,
-		}
-		blockBytes, _ := json.Marshal(b)
-
-		blockData := &outport.BlockData{
-			HeaderBytes: blockBytes,
-			HeaderType:  "Header",
+		revertBlock := &data.RevertBlock{
+			Nonce: 37,
+			Round: 38,
 		}
 
 		dp, err := process.NewEventsDataPreProcessor(createMockEventsDataPreProcessorArgs())
 		require.Nil(t, err)
 
-		err = dp.RevertIndexedBlock(blockData)
+		err = dp.RevertIndexedBlock(revertBlock)
 		require.Nil(t, err)
 	})
 }

--- a/process/eventsIndexer.go
+++ b/process/eventsIndexer.go
@@ -7,6 +7,7 @@ import (
 	"github.com/multiversx/mx-chain-core-go/data/outport"
 	"github.com/multiversx/mx-chain-core-go/marshal"
 	"github.com/multiversx/mx-chain-notifier-go/common"
+	"github.com/multiversx/mx-chain-notifier-go/data"
 )
 
 // ErrNilDataProcessor signals that a nil data processor has been provided
@@ -74,7 +75,7 @@ func (ph *payloadHandler) saveBlock(marshalledData []byte) error {
 }
 
 func (ph *payloadHandler) revertIndexedBlock(marshalledData []byte) error {
-	blockData := &outport.BlockData{}
+	blockData := &data.RevertBlock{}
 	err := ph.marshaller.Unmarshal(blockData, marshalledData)
 	if err != nil {
 		return err

--- a/process/eventsIndexer_test.go
+++ b/process/eventsIndexer_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/multiversx/mx-chain-core-go/data/block"
 	"github.com/multiversx/mx-chain-core-go/data/outport"
 	"github.com/multiversx/mx-chain-notifier-go/common"
+	"github.com/multiversx/mx-chain-notifier-go/data"
 	"github.com/multiversx/mx-chain-notifier-go/mocks"
 	"github.com/multiversx/mx-chain-notifier-go/process"
 	"github.com/stretchr/testify/require"
@@ -88,7 +89,7 @@ func TestProcessPayload(t *testing.T) {
 
 		wasCalled := false
 		dp := &mocks.EventsDataProcessorStub{
-			RevertIndexedBlockCalled: func(blockData *outport.BlockData) error {
+			RevertIndexedBlockCalled: func(blockData *data.RevertBlock) error {
 				wasCalled = true
 				return nil
 			},

--- a/process/interface.go
+++ b/process/interface.go
@@ -54,7 +54,7 @@ type WSClient interface {
 // DataProcessor dines what a data indexer should do
 type DataProcessor interface {
 	SaveBlock(outportBlock *outport.OutportBlock) error
-	RevertIndexedBlock(blockData *outport.BlockData) error
+	RevertIndexedBlock(blockData *data.RevertBlock) error
 	FinalizedBlock(finalizedBlock *outport.FinalizedBlock) error
 	IsInterfaceNil() bool
 }


### PR DESCRIPTION
in node's `rc/v1.6.0` the payload for the bock revert endpoint is of type `RevertData` not `OutportBlock`

- made the required changes + tested on a local testnet with forced rollbacks.