### PR TITLE
Refactor rabbitmq publisher

### DIFF
--- a/common/errors.go
+++ b/common/errors.go
@@ -31,3 +31,6 @@ var ErrNilFacadeHandler = errors.New("nil facade handler")
 
 // ErrNilStatusMetricsHandler signals that a nil status metrics handler has been provided
 var ErrNilStatusMetricsHandler = errors.New("nil status metrics handler")
+
+// ErrWrongTypeAssertion signals a wrong type assertion
+var ErrWrongTypeAssertion = errors.New("wrong type assertion")

--- a/disabled/disabledHub.go
+++ b/disabled/disabledHub.go
@@ -10,7 +10,8 @@ type Hub struct {
 }
 
 // Run does nothing
-func (h *Hub) Run() {
+func (h *Hub) Run() error {
+	return nil
 }
 
 // Broadcast does nothing

--- a/dispatcher/hub/commonHub.go
+++ b/dispatcher/hub/commonHub.go
@@ -74,6 +74,7 @@ func checkArgs(args ArgsCommonHub) error {
 }
 
 // Run is launched as a goroutine and listens for events on the exposed channels
+// TODO: use protection from triggering multiple times
 func (ch *commonHub) Run() error {
 	var ctx context.Context
 	ctx, ch.cancelFunc = context.WithCancel(context.Background())

--- a/dispatcher/hub/commonHub.go
+++ b/dispatcher/hub/commonHub.go
@@ -74,11 +74,13 @@ func checkArgs(args ArgsCommonHub) error {
 }
 
 // Run is launched as a goroutine and listens for events on the exposed channels
-func (ch *commonHub) Run() {
+func (ch *commonHub) Run() error {
 	var ctx context.Context
 	ctx, ch.cancelFunc = context.WithCancel(context.Background())
 
 	go ch.run(ctx)
+
+	return nil
 }
 
 func (ch *commonHub) run(ctx context.Context) {

--- a/dispatcher/interface.go
+++ b/dispatcher/interface.go
@@ -23,7 +23,7 @@ type EventDispatcher interface {
 // Hub defines the behaviour of a hub component which should be able to register
 // and unregister dispatching events
 type Hub interface {
-	Run()
+	Run() error
 	Broadcast(events data.BlockEvents)
 	BroadcastRevert(event data.RevertBlock)
 	BroadcastFinalized(event data.FinalizedBlock)

--- a/factory/hubFactory.go
+++ b/factory/hubFactory.go
@@ -4,8 +4,6 @@ import (
 	"github.com/multiversx/mx-chain-notifier-go/common"
 	"github.com/multiversx/mx-chain-notifier-go/disabled"
 	"github.com/multiversx/mx-chain-notifier-go/dispatcher"
-	"github.com/multiversx/mx-chain-notifier-go/dispatcher/hub"
-	"github.com/multiversx/mx-chain-notifier-go/filters"
 )
 
 // CreateHub creates a common hub component
@@ -18,12 +16,4 @@ func CreateHub(apiType string) (dispatcher.Hub, error) {
 	default:
 		return nil, common.ErrInvalidAPIType
 	}
-}
-
-func createHub() (dispatcher.Hub, error) {
-	args := hub.ArgsCommonHub{
-		Filter:             filters.NewDefaultFilter(),
-		SubscriptionMapper: dispatcher.NewSubscriptionMapper(),
-	}
-	return hub.NewCommonHub(args)
 }

--- a/factory/processFactory.go
+++ b/factory/processFactory.go
@@ -20,22 +20,15 @@ const bech32PubkeyConverterType = "bech32"
 type ArgsEventsHandlerFactory struct {
 	CheckDuplicates      bool
 	Locker               process.LockService
-	MqPublisher          process.Publisher
-	HubPublisher         process.Publisher
-	APIType              string
+	Publisher            process.Publisher
 	StatusMetricsHandler common.StatusMetricsHandler
 }
 
 // CreateEventsHandler will create an events handler processor
 func CreateEventsHandler(args ArgsEventsHandlerFactory) (process.EventsHandler, error) {
-	publisher, err := getPublisher(args.APIType, args.MqPublisher, args.HubPublisher)
-	if err != nil {
-		return nil, err
-	}
-
 	argsEventsHandler := process.ArgsEventsHandler{
 		Locker:               args.Locker,
-		Publisher:            publisher,
+		Publisher:            args.Publisher,
 		StatusMetricsHandler: args.StatusMetricsHandler,
 		CheckDuplicates:      args.CheckDuplicates,
 	}
@@ -45,21 +38,6 @@ func CreateEventsHandler(args ArgsEventsHandlerFactory) (process.EventsHandler, 
 	}
 
 	return eventsHandler, nil
-}
-
-func getPublisher(
-	apiType string,
-	mqPublisher process.Publisher,
-	hubPublisher process.Publisher,
-) (process.Publisher, error) {
-	switch apiType {
-	case common.MessageQueuePublisherType:
-		return mqPublisher, nil
-	case common.WSPublisherType:
-		return hubPublisher, nil
-	default:
-		return nil, common.ErrInvalidAPIType
-	}
 }
 
 // CreateEventsInterceptor will create the events interceptor

--- a/factory/pubsubFactory.go
+++ b/factory/pubsubFactory.go
@@ -7,6 +7,7 @@ import (
 	"github.com/multiversx/mx-chain-notifier-go/dispatcher"
 	"github.com/multiversx/mx-chain-notifier-go/dispatcher/hub"
 	"github.com/multiversx/mx-chain-notifier-go/filters"
+	"github.com/multiversx/mx-chain-notifier-go/process"
 	"github.com/multiversx/mx-chain-notifier-go/rabbitmq"
 )
 
@@ -38,7 +39,12 @@ func createRabbitMqPublisher(config config.RabbitMQConfig, marshaller marshal.Ma
 		return nil, err
 	}
 
-	return rabbitPublisher, nil
+	publisher, err := process.NewPublisher(rabbitPublisher)
+	if err != nil {
+		return nil, err
+	}
+
+	return publisher, nil
 }
 
 func createHub() (dispatcher.Hub, error) {

--- a/factory/pubsubFactory.go
+++ b/factory/pubsubFactory.go
@@ -4,7 +4,9 @@ import (
 	"github.com/multiversx/mx-chain-core-go/marshal"
 	"github.com/multiversx/mx-chain-notifier-go/common"
 	"github.com/multiversx/mx-chain-notifier-go/config"
-	"github.com/multiversx/mx-chain-notifier-go/disabled"
+	"github.com/multiversx/mx-chain-notifier-go/dispatcher"
+	"github.com/multiversx/mx-chain-notifier-go/dispatcher/hub"
+	"github.com/multiversx/mx-chain-notifier-go/filters"
 	"github.com/multiversx/mx-chain-notifier-go/rabbitmq"
 )
 
@@ -14,7 +16,7 @@ func CreatePublisher(apiType string, config config.MainConfig, marshaller marsha
 	case common.MessageQueuePublisherType:
 		return createRabbitMqPublisher(config.RabbitMQ, marshaller)
 	case common.WSPublisherType:
-		return &disabled.Publisher{}, nil
+		return createHub()
 	default:
 		return nil, common.ErrInvalidAPIType
 	}
@@ -37,4 +39,12 @@ func createRabbitMqPublisher(config config.RabbitMQConfig, marshaller marshal.Ma
 	}
 
 	return rabbitPublisher, nil
+}
+
+func createHub() (dispatcher.Hub, error) {
+	args := hub.ArgsCommonHub{
+		Filter:             filters.NewDefaultFilter(),
+		SubscriptionMapper: dispatcher.NewSubscriptionMapper(),
+	}
+	return hub.NewCommonHub(args)
 }

--- a/factory/wsFactory.go
+++ b/factory/wsFactory.go
@@ -23,7 +23,6 @@ func CreateWSHandler(apiType string, publisher process.Publisher, marshaller mar
 	// TODO: remove this after refactoring WS publisher
 	hub, ok := publisher.(dispatcher.Hub)
 	if !ok {
-		log.Warn("unable to cast publisher to hub")
 		return nil, common.ErrWrongTypeAssertion
 	}
 

--- a/factory/wsFactory.go
+++ b/factory/wsFactory.go
@@ -19,7 +19,13 @@ const (
 )
 
 // CreateWSHandler creates websocket handler component based on api type
-func CreateWSHandler(apiType string, hub dispatcher.Hub, marshaller marshal.Marshalizer) (dispatcher.WSHandler, error) {
+func CreateWSHandler(apiType string, publisher process.Publisher, marshaller marshal.Marshalizer) (dispatcher.WSHandler, error) {
+	// TODO: remove this after refactoring WS publisher
+	hub, ok := publisher.(dispatcher.Hub)
+	if !ok {
+		log.Warn("unable to cast publisher to hub")
+	}
+
 	switch apiType {
 	case common.MessageQueuePublisherType:
 		return &disabled.WSHandler{}, nil

--- a/factory/wsFactory.go
+++ b/factory/wsFactory.go
@@ -24,6 +24,7 @@ func CreateWSHandler(apiType string, publisher process.Publisher, marshaller mar
 	hub, ok := publisher.(dispatcher.Hub)
 	if !ok {
 		log.Warn("unable to cast publisher to hub")
+		return nil, common.ErrWrongTypeAssertion
 	}
 
 	switch apiType {

--- a/integrationTests/interface.go
+++ b/integrationTests/interface.go
@@ -7,7 +7,7 @@ import (
 
 // PublisherHandler defines publisher behaviour
 type PublisherHandler interface {
-	Run()
+	Run() error
 	Broadcast(events data.BlockEvents)
 	BroadcastRevert(event data.RevertBlock)
 	BroadcastFinalized(event data.FinalizedBlock)

--- a/integrationTests/rabbitmq/testNotifierWithRabbitMQ_test.go
+++ b/integrationTests/rabbitmq/testNotifierWithRabbitMQ_test.go
@@ -43,7 +43,7 @@ func testNotifierWithRabbitMQ(t *testing.T, observerType string, payloadVersion 
 	client, err := integrationTests.CreateObserverConnector(notifier.Facade, observerType, common.MessageQueuePublisherType, common.PayloadV1)
 	require.Nil(t, err)
 
-	notifier.Publisher.Run()
+	_ = notifier.Publisher.Run()
 	defer notifier.Publisher.Close()
 
 	wg := &sync.WaitGroup{}

--- a/integrationTests/testNotifierProxy.go
+++ b/integrationTests/testNotifierProxy.go
@@ -124,7 +124,11 @@ func NewTestNotifierWithRabbitMq(cfg config.MainConfig) (*testNotifier, error) {
 		Config:     cfg.RabbitMQ,
 		Marshaller: marshaller,
 	}
-	publisher, err := rabbitmq.NewRabbitMqPublisher(publisherArgs)
+	publisherHandler, err := rabbitmq.NewRabbitMqPublisher(publisherArgs)
+	if err != nil {
+		return nil, err
+	}
+	publisher, err := process.NewPublisher(publisherHandler)
 	if err != nil {
 		return nil, err
 	}

--- a/integrationTests/websocket/testNotifierWithWebsockets_test.go
+++ b/integrationTests/websocket/testNotifierWithWebsockets_test.go
@@ -27,7 +27,7 @@ func TestNotifierWithWebsockets_PushEvents(t *testing.T) {
 	webServer, err := integrationTests.CreateObserverConnector(notifier.Facade, common.HTTPConnectorType, common.WSPublisherType, common.PayloadV1)
 	require.Nil(t, err)
 
-	notifier.Publisher.Run()
+	_ = notifier.Publisher.Run()
 	defer notifier.Publisher.Close()
 
 	ws, err := integrationTests.NewWSClient(notifier.WSHandler)
@@ -112,7 +112,7 @@ func TestNotifierWithWebsockets_BlockEvents(t *testing.T) {
 	webServer, err := integrationTests.CreateObserverConnector(notifier.Facade, common.HTTPConnectorType, common.WSPublisherType, common.PayloadV1)
 	require.Nil(t, err)
 
-	notifier.Publisher.Run()
+	_ = notifier.Publisher.Run()
 	defer notifier.Publisher.Close()
 
 	ws, err := integrationTests.NewWSClient(notifier.WSHandler)
@@ -204,7 +204,7 @@ func TestNotifierWithWebsockets_RevertEvents(t *testing.T) {
 	webServer, err := integrationTests.CreateObserverConnector(notifier.Facade, common.HTTPConnectorType, common.WSPublisherType, common.PayloadV1)
 	require.Nil(t, err)
 
-	notifier.Publisher.Run()
+	_ = notifier.Publisher.Run()
 	defer notifier.Publisher.Close()
 
 	ws, err := integrationTests.NewWSClient(notifier.WSHandler)
@@ -265,7 +265,7 @@ func TestNotifierWithWebsockets_FinalizedEvents(t *testing.T) {
 	webServer, err := integrationTests.CreateObserverConnector(notifier.Facade, common.HTTPConnectorType, common.WSPublisherType, common.PayloadV1)
 	require.Nil(t, err)
 
-	notifier.Publisher.Run()
+	_ = notifier.Publisher.Run()
 	defer notifier.Publisher.Close()
 
 	ws, err := integrationTests.NewWSClient(notifier.WSHandler)
@@ -316,7 +316,7 @@ func TestNotifierWithWebsockets_TxsEvents(t *testing.T) {
 	webServer, err := integrationTests.CreateObserverConnector(notifier.Facade, common.HTTPConnectorType, common.WSPublisherType, common.PayloadV1)
 	require.Nil(t, err)
 
-	notifier.Publisher.Run()
+	_ = notifier.Publisher.Run()
 	defer notifier.Publisher.Close()
 
 	ws, err := integrationTests.NewWSClient(notifier.WSHandler)
@@ -400,7 +400,7 @@ func TestNotifierWithWebsockets_ScrsEvents(t *testing.T) {
 	webServer, err := integrationTests.CreateObserverConnector(notifier.Facade, common.HTTPConnectorType, common.WSPublisherType, common.PayloadV1)
 	require.Nil(t, err)
 
-	notifier.Publisher.Run()
+	_ = notifier.Publisher.Run()
 	defer notifier.Publisher.Close()
 
 	ws, err := integrationTests.NewWSClient(notifier.WSHandler)
@@ -494,7 +494,7 @@ func testNotifierWithWebsockets_AllEvents(t *testing.T, observerType string) {
 	client, err := integrationTests.CreateObserverConnector(notifier.Facade, observerType, common.MessageQueuePublisherType, common.PayloadV1)
 	require.Nil(t, err)
 
-	notifier.Publisher.Run()
+	_ = notifier.Publisher.Run()
 	defer notifier.Publisher.Close()
 
 	ws, err := integrationTests.NewWSClient(notifier.WSHandler)

--- a/mocks/hubStub.go
+++ b/mocks/hubStub.go
@@ -7,7 +7,7 @@ import (
 
 // HubStub implements Hub interface
 type HubStub struct {
-	RunCalled                           func()
+	RunCalled                           func() error
 	BroadcastCalled                     func(events data.BlockEvents)
 	BroadcastRevertCalled               func(event data.RevertBlock)
 	BroadcastFinalizedCalled            func(event data.FinalizedBlock)
@@ -21,10 +21,12 @@ type HubStub struct {
 }
 
 // Run -
-func (h *HubStub) Run() {
+func (h *HubStub) Run() error {
 	if h.RunCalled != nil {
-		h.RunCalled()
+		return h.RunCalled()
 	}
+
+	return nil
 }
 
 // Broadcast -

--- a/mocks/publisherHandlerStub.go
+++ b/mocks/publisherHandlerStub.go
@@ -1,0 +1,68 @@
+package mocks
+
+import "github.com/multiversx/mx-chain-notifier-go/data"
+
+// PublisherHandlerStub -
+type PublisherHandlerStub struct {
+	PublishCalled                     func(events data.BlockEvents)
+	PublishRevertCalled               func(revertBlock data.RevertBlock)
+	PublishFinalizedCalled            func(finalizedBlock data.FinalizedBlock)
+	PublishTxsCalled                  func(blockTxs data.BlockTxs)
+	PublishScrsCalled                 func(blockScrs data.BlockScrs)
+	PublishBlockEventsWithOrderCalled func(blockTxs data.BlockEventsWithOrder)
+	CloseCalled                       func()
+}
+
+// Publish -
+func (p *PublisherHandlerStub) Publish(events data.BlockEvents) {
+	if p.PublishCalled != nil {
+		p.PublishCalled(events)
+	}
+}
+
+// PublishRevert -
+func (p *PublisherHandlerStub) PublishRevert(revertBlock data.RevertBlock) {
+	if p.PublishRevertCalled != nil {
+		p.PublishRevertCalled(revertBlock)
+	}
+}
+
+// PublishFinalized -
+func (p *PublisherHandlerStub) PublishFinalized(finalizedBlock data.FinalizedBlock) {
+	if p.PublishFinalizedCalled != nil {
+		p.PublishFinalizedCalled(finalizedBlock)
+	}
+}
+
+// PublishTxs -
+func (p *PublisherHandlerStub) PublishTxs(blockTxs data.BlockTxs) {
+	if p.PublishTxsCalled != nil {
+		p.PublishTxsCalled(blockTxs)
+	}
+}
+
+// PublishScrs -
+func (p *PublisherHandlerStub) PublishScrs(blockScrs data.BlockScrs) {
+	if p.PublishScrsCalled != nil {
+		p.PublishScrsCalled(blockScrs)
+	}
+}
+
+// PublishBlockEventsWithOrder -
+func (p *PublisherHandlerStub) PublishBlockEventsWithOrder(blockTxs data.BlockEventsWithOrder) {
+	if p.PublishBlockEventsWithOrderCalled != nil {
+		p.PublishBlockEventsWithOrderCalled(blockTxs)
+	}
+}
+
+// Close -
+func (p *PublisherHandlerStub) Close() {
+	if p.CloseCalled != nil {
+		p.CloseCalled()
+	}
+}
+
+// IsInterfaceNil -
+func (p *PublisherHandlerStub) IsInterfaceNil() bool {
+	return p == nil
+}

--- a/notifier/notifierRunner.go
+++ b/notifier/notifierRunner.go
@@ -94,7 +94,10 @@ func (nr *notifierRunner) Start() error {
 		return err
 	}
 
-	publisher.Run()
+	err = publisher.Run()
+	if err != nil {
+		return err
+	}
 
 	err = webServer.Run()
 	if err != nil {

--- a/notifier/notifierRunner.go
+++ b/notifier/notifierRunner.go
@@ -50,12 +50,7 @@ func (nr *notifierRunner) Start() error {
 		return err
 	}
 
-	hub, err := factory.CreateHub(nr.configs.Flags.PublisherType)
-	if err != nil {
-		return err
-	}
-
-	wsHandler, err := factory.CreateWSHandler(nr.configs.Flags.PublisherType, hub, externalMarshaller)
+	wsHandler, err := factory.CreateWSHandler(nr.configs.Flags.PublisherType, publisher, externalMarshaller)
 	if err != nil {
 		return err
 	}
@@ -65,9 +60,7 @@ func (nr *notifierRunner) Start() error {
 	argsEventsHandler := factory.ArgsEventsHandlerFactory{
 		CheckDuplicates:      nr.configs.MainConfig.General.CheckDuplicates,
 		Locker:               lockService,
-		MqPublisher:          publisher,
-		HubPublisher:         hub,
-		APIType:              nr.configs.Flags.PublisherType,
+		Publisher:            publisher,
 		StatusMetricsHandler: statusMetricsHandler,
 	}
 	eventsHandler, err := factory.CreateEventsHandler(argsEventsHandler)

--- a/process/errors.go
+++ b/process/errors.go
@@ -28,3 +28,6 @@ var ErrNilBlockHeader = errors.New("nil block header provided")
 
 // ErrNilPublisherHandler signals that a nil publisher handler has been provided
 var ErrNilPublisherHandler = errors.New("nil publisher handler provided")
+
+// ErrLoopAlreadyStarted signals that a loop has already been started
+var ErrLoopAlreadyStarted = errors.New("loop already started")

--- a/process/errors.go
+++ b/process/errors.go
@@ -25,3 +25,6 @@ var ErrNilBlockBody = errors.New("nil block body provided")
 
 // ErrNilBlockHeader signals that a nil block header has been provided
 var ErrNilBlockHeader = errors.New("nil block header provided")
+
+// ErrNilPublisherHandler signals that a nil publisher handler has been provided
+var ErrNilPublisherHandler = errors.New("nil publisher handler provided")

--- a/process/interface.go
+++ b/process/interface.go
@@ -63,3 +63,15 @@ type EventsFacadeHandler interface {
 	HandleFinalizedEvents(finalizedBlock data.FinalizedBlock)
 	IsInterfaceNil() bool
 }
+
+// PublisherHandler defines the behavior of a publisher component
+type PublisherHandler interface {
+	Publish(events data.BlockEvents)
+	PublishRevert(revertBlock data.RevertBlock)
+	PublishFinalized(finalizedBlock data.FinalizedBlock)
+	PublishTxs(blockTxs data.BlockTxs)
+	PublishScrs(blockScrs data.BlockScrs)
+	PublishBlockEventsWithOrder(blockTxs data.BlockEventsWithOrder)
+	Close()
+	IsInterfaceNil() bool
+}

--- a/process/publisher.go
+++ b/process/publisher.go
@@ -1,0 +1,127 @@
+package process
+
+import (
+	"context"
+
+	"github.com/multiversx/mx-chain-notifier-go/data"
+)
+
+type publisherHandler interface {
+	Publish(events data.BlockEvents)
+	PublishRevert(revertBlock data.RevertBlock)
+	PublishFinalized(finalizedBlock data.FinalizedBlock)
+	PublishTxs(blockTxs data.BlockTxs)
+	PublishScrs(blockScrs data.BlockScrs)
+	PublishBlockEventsWithOrder(blockTxs data.BlockEventsWithOrder)
+	Close()
+}
+
+type publisher struct {
+	handler publisherHandler
+
+	broadcast                     chan data.BlockEvents
+	broadcastRevert               chan data.RevertBlock
+	broadcastFinalized            chan data.FinalizedBlock
+	broadcastTxs                  chan data.BlockTxs
+	broadcastBlockEventsWithOrder chan data.BlockEventsWithOrder
+	broadcastScrs                 chan data.BlockScrs
+
+	cancelFunc func()
+	closeChan  chan struct{}
+}
+
+func NewPublisher() (Publisher, error) {
+	p := &publisher{
+		broadcast:                     make(chan data.BlockEvents),
+		broadcastRevert:               make(chan data.RevertBlock),
+		broadcastFinalized:            make(chan data.FinalizedBlock),
+		broadcastTxs:                  make(chan data.BlockTxs),
+		broadcastScrs:                 make(chan data.BlockScrs),
+		broadcastBlockEventsWithOrder: make(chan data.BlockEventsWithOrder),
+		closeChan:                     make(chan struct{}),
+	}
+
+	return p, nil
+}
+
+// Run is launched as a goroutine and listens for events on the exposed channels
+func (p *publisher) Run() {
+	var ctx context.Context
+	ctx, p.cancelFunc = context.WithCancel(context.Background())
+
+	go p.run(ctx)
+}
+
+func (p *publisher) run(ctx context.Context) {
+	for {
+		select {
+		case <-ctx.Done():
+			p.handler.Close()
+		case events := <-p.broadcast:
+			p.handler.Publish(events)
+		case revertBlock := <-p.broadcastRevert:
+			p.handler.PublishRevert(revertBlock)
+		case finalizedBlock := <-p.broadcastFinalized:
+			p.handler.PublishFinalized(finalizedBlock)
+		case blockTxs := <-p.broadcastTxs:
+			p.handler.PublishTxs(blockTxs)
+		case blockScrs := <-p.broadcastScrs:
+			p.handler.PublishScrs(blockScrs)
+		case blockEvents := <-p.broadcastBlockEventsWithOrder:
+			p.handler.PublishBlockEventsWithOrder(blockEvents)
+		}
+	}
+}
+
+// Broadcast will handle the block events pushed by producers and sends them to rabbitMQ channel
+func (p *publisher) Broadcast(events data.BlockEvents) {
+	select {
+	case p.broadcast <- events:
+	case <-p.closeChan:
+	}
+}
+
+// BroadcastRevert will handle the revert event pushed by producers and sends them to rabbitMQ channel
+func (p *publisher) BroadcastRevert(events data.RevertBlock) {
+	select {
+	case p.broadcastRevert <- events:
+	case <-p.closeChan:
+	}
+}
+
+// BroadcastFinalized will handle the finalized event pushed by producers and sends them to rabbitMQ channel
+func (p *publisher) BroadcastFinalized(events data.FinalizedBlock) {
+	select {
+	case p.broadcastFinalized <- events:
+	case <-p.closeChan:
+	}
+}
+
+// BroadcastTxs will handle the txs event pushed by producers and sends them to rabbitMQ channel
+func (p *publisher) BroadcastTxs(events data.BlockTxs) {
+	select {
+	case p.broadcastTxs <- events:
+	case <-p.closeChan:
+	}
+}
+
+// BroadcastScrs will handle the scrs event pushed by producers and sends them to rabbitMQ channel
+func (p *publisher) BroadcastScrs(events data.BlockScrs) {
+	select {
+	case p.broadcastScrs <- events:
+	case <-p.closeChan:
+	}
+}
+
+// BroadcastBlockEventsWithOrder will handle the full block events pushed by producers and sends them to rabbitMQ channel
+func (p *publisher) BroadcastBlockEventsWithOrder(events data.BlockEventsWithOrder) {
+	select {
+	case p.broadcastBlockEventsWithOrder <- events:
+	case <-p.closeChan:
+	}
+}
+
+// IsInterfaceNil returns true if there is no value under the interface
+func (p *publisher) IsInterfaceNil() bool {
+	return p == nil
+}

--- a/process/publisher_test.go
+++ b/process/publisher_test.go
@@ -1,0 +1,206 @@
+package process_test
+
+import (
+	"sync"
+	"sync/atomic"
+	"testing"
+
+	"github.com/multiversx/mx-chain-notifier-go/data"
+	"github.com/multiversx/mx-chain-notifier-go/mocks"
+	"github.com/multiversx/mx-chain-notifier-go/process"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewPublisher(t *testing.T) {
+	t.Parallel()
+
+	t.Run("nil handler", func(t *testing.T) {
+		t.Parallel()
+
+		p, err := process.NewPublisher(nil)
+		require.Nil(t, p)
+		require.Equal(t, process.ErrNilPublisherHandler, err)
+	})
+
+	t.Run("should work", func(t *testing.T) {
+		t.Parallel()
+
+		p, err := process.NewPublisher(&mocks.PublisherHandlerStub{})
+		require.Nil(t, err)
+		require.False(t, p.IsInterfaceNil())
+	})
+}
+
+func TestBroadcast(t *testing.T) {
+	t.Parallel()
+
+	wg := sync.WaitGroup{}
+	numCalls := uint32(0)
+
+	ph := &mocks.PublisherHandlerStub{
+		PublishCalled: func(events data.BlockEvents) {
+			atomic.AddUint32(&numCalls, 1)
+			wg.Done()
+		},
+	}
+
+	p, err := process.NewPublisher(ph)
+	require.Nil(t, err)
+
+	p.Run()
+	defer p.Close()
+	wg.Add(1)
+
+	p.Broadcast(data.BlockEvents{})
+
+	wg.Wait()
+
+	require.Equal(t, uint32(1), atomic.LoadUint32(&numCalls))
+}
+
+func TestBroadcastRevert(t *testing.T) {
+	t.Parallel()
+
+	wg := sync.WaitGroup{}
+	numCalls := uint32(0)
+
+	ph := &mocks.PublisherHandlerStub{
+		PublishRevertCalled: func(revertBlock data.RevertBlock) {
+			atomic.AddUint32(&numCalls, 1)
+			wg.Done()
+		},
+	}
+
+	p, err := process.NewPublisher(ph)
+	require.Nil(t, err)
+
+	p.Run()
+	defer p.Close()
+	wg.Add(1)
+
+	p.BroadcastRevert(data.RevertBlock{})
+
+	wg.Wait()
+
+	require.Equal(t, uint32(1), atomic.LoadUint32(&numCalls))
+}
+
+func TestBroadcastFinalized(t *testing.T) {
+	t.Parallel()
+
+	wg := sync.WaitGroup{}
+	numCalls := uint32(0)
+
+	ph := &mocks.PublisherHandlerStub{
+		PublishFinalizedCalled: func(finalizedBlock data.FinalizedBlock) {
+			atomic.AddUint32(&numCalls, 1)
+			wg.Done()
+		},
+	}
+
+	p, err := process.NewPublisher(ph)
+	require.Nil(t, err)
+
+	p.Run()
+	defer p.Close()
+	wg.Add(1)
+
+	p.BroadcastFinalized(data.FinalizedBlock{})
+
+	wg.Wait()
+
+	require.Equal(t, uint32(1), atomic.LoadUint32(&numCalls))
+}
+
+func TestBroadcastTxs(t *testing.T) {
+	t.Parallel()
+
+	wg := sync.WaitGroup{}
+	numCalls := uint32(0)
+
+	ph := &mocks.PublisherHandlerStub{
+		PublishTxsCalled: func(blockTxs data.BlockTxs) {
+			atomic.AddUint32(&numCalls, 1)
+			wg.Done()
+		},
+	}
+
+	p, err := process.NewPublisher(ph)
+	require.Nil(t, err)
+
+	p.Run()
+	defer p.Close()
+	wg.Add(1)
+
+	p.BroadcastTxs(data.BlockTxs{})
+
+	wg.Wait()
+
+	require.Equal(t, uint32(1), atomic.LoadUint32(&numCalls))
+}
+
+func TestBroadcastScrs(t *testing.T) {
+	t.Parallel()
+
+	wg := sync.WaitGroup{}
+	numCalls := uint32(0)
+
+	ph := &mocks.PublisherHandlerStub{
+		PublishScrsCalled: func(blockScrs data.BlockScrs) {
+			atomic.AddUint32(&numCalls, 1)
+			wg.Done()
+		},
+	}
+
+	p, err := process.NewPublisher(ph)
+	require.Nil(t, err)
+
+	p.Run()
+	defer p.Close()
+	wg.Add(1)
+
+	p.BroadcastScrs(data.BlockScrs{})
+
+	wg.Wait()
+
+	require.Equal(t, uint32(1), atomic.LoadUint32(&numCalls))
+}
+
+func TestBroadcastBlockEventsWithOrder(t *testing.T) {
+	t.Parallel()
+
+	wg := sync.WaitGroup{}
+	numCalls := uint32(0)
+
+	ph := &mocks.PublisherHandlerStub{
+		PublishBlockEventsWithOrderCalled: func(blockTxs data.BlockEventsWithOrder) {
+			atomic.AddUint32(&numCalls, 1)
+			wg.Done()
+		},
+	}
+
+	p, err := process.NewPublisher(ph)
+	require.Nil(t, err)
+
+	p.Run()
+	defer p.Close()
+	wg.Add(1)
+
+	p.BroadcastBlockEventsWithOrder(data.BlockEventsWithOrder{})
+
+	wg.Wait()
+
+	require.Equal(t, uint32(1), atomic.LoadUint32(&numCalls))
+}
+
+func TestClose(t *testing.T) {
+	t.Parallel()
+
+	p, err := process.NewPublisher(&mocks.PublisherHandlerStub{})
+	require.Nil(t, err)
+
+	p.Run()
+
+	err = p.Close()
+	require.Nil(t, err)
+}

--- a/rabbitmq/interface.go
+++ b/rabbitmq/interface.go
@@ -20,7 +20,7 @@ type RabbitMqClient interface {
 // PublisherService defines the behaviour of a publisher component which should be
 // able to publish received events and broadcast them to channels
 type PublisherService interface {
-	Run()
+	Run() error
 	Broadcast(events data.BlockEvents)
 	BroadcastRevert(event data.RevertBlock)
 	BroadcastFinalized(event data.FinalizedBlock)

--- a/rabbitmq/publisher.go
+++ b/rabbitmq/publisher.go
@@ -142,6 +142,7 @@ func (rp *rabbitMqPublisher) createExchange(conf config.RabbitMQExchangeConfig) 
 	return nil
 }
 
+// Publish will publish logs and events to rabbitmq
 func (rp *rabbitMqPublisher) Publish(events data.BlockEvents) {
 	eventsBytes, err := rp.marshaller.Marshal(events)
 	if err != nil {
@@ -155,6 +156,7 @@ func (rp *rabbitMqPublisher) Publish(events data.BlockEvents) {
 	}
 }
 
+// PublishRevert will publish revert event to rabbitmq
 func (rp *rabbitMqPublisher) PublishRevert(revertBlock data.RevertBlock) {
 	revertBlockBytes, err := rp.marshaller.Marshal(revertBlock)
 	if err != nil {
@@ -168,6 +170,7 @@ func (rp *rabbitMqPublisher) PublishRevert(revertBlock data.RevertBlock) {
 	}
 }
 
+// PublishFinalized will publish finalized event to rabbitmq
 func (rp *rabbitMqPublisher) PublishFinalized(finalizedBlock data.FinalizedBlock) {
 	finalizedBlockBytes, err := rp.marshaller.Marshal(finalizedBlock)
 	if err != nil {
@@ -181,6 +184,7 @@ func (rp *rabbitMqPublisher) PublishFinalized(finalizedBlock data.FinalizedBlock
 	}
 }
 
+// PublishTxs will publish txs event to rabbitmq
 func (rp *rabbitMqPublisher) PublishTxs(blockTxs data.BlockTxs) {
 	txsBlockBytes, err := rp.marshaller.Marshal(blockTxs)
 	if err != nil {
@@ -194,6 +198,7 @@ func (rp *rabbitMqPublisher) PublishTxs(blockTxs data.BlockTxs) {
 	}
 }
 
+// PublishTxs will publish scrs event to rabbitmq
 func (rp *rabbitMqPublisher) PublishScrs(blockScrs data.BlockScrs) {
 	scrsBlockBytes, err := rp.marshaller.Marshal(blockScrs)
 	if err != nil {
@@ -207,6 +212,7 @@ func (rp *rabbitMqPublisher) PublishScrs(blockScrs data.BlockScrs) {
 	}
 }
 
+// PublishBlockEventsWithOrder will publish block events with order to rabbitmq
 func (rp *rabbitMqPublisher) PublishBlockEventsWithOrder(blockTxs data.BlockEventsWithOrder) {
 	txsBlockBytes, err := rp.marshaller.Marshal(blockTxs)
 	if err != nil {

--- a/rabbitmq/publisher.go
+++ b/rabbitmq/publisher.go
@@ -1,8 +1,6 @@
 package rabbitmq
 
 import (
-	"context"
-
 	"github.com/multiversx/mx-chain-core-go/core/check"
 	"github.com/multiversx/mx-chain-core-go/marshal"
 	logger "github.com/multiversx/mx-chain-logger-go"
@@ -30,13 +28,6 @@ type rabbitMqPublisher struct {
 	marshaller marshal.Marshalizer
 	cfg        config.RabbitMQConfig
 
-	broadcast                     chan data.BlockEvents
-	broadcastRevert               chan data.RevertBlock
-	broadcastFinalized            chan data.FinalizedBlock
-	broadcastTxs                  chan data.BlockTxs
-	broadcastBlockEventsWithOrder chan data.BlockEventsWithOrder
-	broadcastScrs                 chan data.BlockScrs
-
 	cancelFunc func()
 	closeChan  chan struct{}
 }
@@ -49,16 +40,9 @@ func NewRabbitMqPublisher(args ArgsRabbitMqPublisher) (*rabbitMqPublisher, error
 	}
 
 	rp := &rabbitMqPublisher{
-		broadcast:                     make(chan data.BlockEvents),
-		broadcastRevert:               make(chan data.RevertBlock),
-		broadcastFinalized:            make(chan data.FinalizedBlock),
-		broadcastTxs:                  make(chan data.BlockTxs),
-		broadcastScrs:                 make(chan data.BlockScrs),
-		broadcastBlockEventsWithOrder: make(chan data.BlockEventsWithOrder),
-		cfg:                           args.Config,
-		client:                        args.Client,
-		marshaller:                    args.Marshaller,
-		closeChan:                     make(chan struct{}),
+		cfg:        args.Config,
+		client:     args.Client,
+		marshaller: args.Marshaller,
 	}
 
 	err = rp.createExchanges()
@@ -158,95 +142,7 @@ func (rp *rabbitMqPublisher) createExchange(conf config.RabbitMQExchangeConfig) 
 	return nil
 }
 
-// Run is launched as a goroutine and listens for events on the exposed channels
-func (rp *rabbitMqPublisher) Run() {
-	var ctx context.Context
-	ctx, rp.cancelFunc = context.WithCancel(context.Background())
-
-	go rp.run(ctx)
-}
-
-func (rp *rabbitMqPublisher) run(ctx context.Context) {
-	for {
-		select {
-		case <-ctx.Done():
-			log.Debug("RabbitMQ publisher is stopping...")
-			rp.client.Close()
-		case events := <-rp.broadcast:
-			rp.publishToExchanges(events)
-		case revertBlock := <-rp.broadcastRevert:
-			rp.publishRevertToExchange(revertBlock)
-		case finalizedBlock := <-rp.broadcastFinalized:
-			rp.publishFinalizedToExchange(finalizedBlock)
-		case blockTxs := <-rp.broadcastTxs:
-			rp.publishTxsToExchange(blockTxs)
-		case blockScrs := <-rp.broadcastScrs:
-			rp.publishScrsToExchange(blockScrs)
-		case blockEvents := <-rp.broadcastBlockEventsWithOrder:
-			rp.publishBlockEventsWithOrderToExchange(blockEvents)
-		case err := <-rp.client.ConnErrChan():
-			if err != nil {
-				log.Error("rabbitMQ connection failure", "err", err.Error())
-				rp.client.Reconnect()
-			}
-		case err := <-rp.client.CloseErrChan():
-			if err != nil {
-				log.Error("rabbitMQ channel failure", "err", err.Error())
-				rp.client.ReopenChannel()
-			}
-		}
-	}
-}
-
-// Broadcast will handle the block events pushed by producers and sends them to rabbitMQ channel
-func (rp *rabbitMqPublisher) Broadcast(events data.BlockEvents) {
-	select {
-	case rp.broadcast <- events:
-	case <-rp.closeChan:
-	}
-}
-
-// BroadcastRevert will handle the revert event pushed by producers and sends them to rabbitMQ channel
-func (rp *rabbitMqPublisher) BroadcastRevert(events data.RevertBlock) {
-	select {
-	case rp.broadcastRevert <- events:
-	case <-rp.closeChan:
-	}
-}
-
-// BroadcastFinalized will handle the finalized event pushed by producers and sends them to rabbitMQ channel
-func (rp *rabbitMqPublisher) BroadcastFinalized(events data.FinalizedBlock) {
-	select {
-	case rp.broadcastFinalized <- events:
-	case <-rp.closeChan:
-	}
-}
-
-// BroadcastTxs will handle the txs event pushed by producers and sends them to rabbitMQ channel
-func (rp *rabbitMqPublisher) BroadcastTxs(events data.BlockTxs) {
-	select {
-	case rp.broadcastTxs <- events:
-	case <-rp.closeChan:
-	}
-}
-
-// BroadcastScrs will handle the scrs event pushed by producers and sends them to rabbitMQ channel
-func (rp *rabbitMqPublisher) BroadcastScrs(events data.BlockScrs) {
-	select {
-	case rp.broadcastScrs <- events:
-	case <-rp.closeChan:
-	}
-}
-
-// BroadcastBlockEventsWithOrder will handle the full block events pushed by producers and sends them to rabbitMQ channel
-func (rp *rabbitMqPublisher) BroadcastBlockEventsWithOrder(events data.BlockEventsWithOrder) {
-	select {
-	case rp.broadcastBlockEventsWithOrder <- events:
-	case <-rp.closeChan:
-	}
-}
-
-func (rp *rabbitMqPublisher) publishToExchanges(events data.BlockEvents) {
+func (rp *rabbitMqPublisher) Publish(events data.BlockEvents) {
 	eventsBytes, err := rp.marshaller.Marshal(events)
 	if err != nil {
 		log.Error("could not marshal events", "err", err.Error())
@@ -259,7 +155,7 @@ func (rp *rabbitMqPublisher) publishToExchanges(events data.BlockEvents) {
 	}
 }
 
-func (rp *rabbitMqPublisher) publishRevertToExchange(revertBlock data.RevertBlock) {
+func (rp *rabbitMqPublisher) PublishRevert(revertBlock data.RevertBlock) {
 	revertBlockBytes, err := rp.marshaller.Marshal(revertBlock)
 	if err != nil {
 		log.Error("could not marshal revert event", "err", err.Error())
@@ -272,7 +168,7 @@ func (rp *rabbitMqPublisher) publishRevertToExchange(revertBlock data.RevertBloc
 	}
 }
 
-func (rp *rabbitMqPublisher) publishFinalizedToExchange(finalizedBlock data.FinalizedBlock) {
+func (rp *rabbitMqPublisher) PublishFinalized(finalizedBlock data.FinalizedBlock) {
 	finalizedBlockBytes, err := rp.marshaller.Marshal(finalizedBlock)
 	if err != nil {
 		log.Error("could not marshal finalized event", "err", err.Error())
@@ -285,7 +181,7 @@ func (rp *rabbitMqPublisher) publishFinalizedToExchange(finalizedBlock data.Fina
 	}
 }
 
-func (rp *rabbitMqPublisher) publishTxsToExchange(blockTxs data.BlockTxs) {
+func (rp *rabbitMqPublisher) PublishTxs(blockTxs data.BlockTxs) {
 	txsBlockBytes, err := rp.marshaller.Marshal(blockTxs)
 	if err != nil {
 		log.Error("could not marshal block txs event", "err", err.Error())
@@ -298,7 +194,7 @@ func (rp *rabbitMqPublisher) publishTxsToExchange(blockTxs data.BlockTxs) {
 	}
 }
 
-func (rp *rabbitMqPublisher) publishScrsToExchange(blockScrs data.BlockScrs) {
+func (rp *rabbitMqPublisher) PublishScrs(blockScrs data.BlockScrs) {
 	scrsBlockBytes, err := rp.marshaller.Marshal(blockScrs)
 	if err != nil {
 		log.Error("could not marshal block scrs event", "err", err.Error())
@@ -311,7 +207,7 @@ func (rp *rabbitMqPublisher) publishScrsToExchange(blockScrs data.BlockScrs) {
 	}
 }
 
-func (rp *rabbitMqPublisher) publishBlockEventsWithOrderToExchange(blockTxs data.BlockEventsWithOrder) {
+func (rp *rabbitMqPublisher) PublishBlockEventsWithOrder(blockTxs data.BlockEventsWithOrder) {
 	txsBlockBytes, err := rp.marshaller.Marshal(blockTxs)
 	if err != nil {
 		log.Error("could not marshal block txs event", "err", err.Error())
@@ -336,15 +232,9 @@ func (rp *rabbitMqPublisher) publishFanout(exchangeName string, payload []byte) 
 	)
 }
 
-// Close will close the channels
-func (rp *rabbitMqPublisher) Close() error {
-	if rp.cancelFunc != nil {
-		rp.cancelFunc()
-	}
-
-	close(rp.closeChan)
-
-	return nil
+// Close will trigger to close rabbitmq client
+func (rp *rabbitMqPublisher) Close() {
+	rp.client.Close()
 }
 
 // IsInterfaceNil returns true if there is no value under the interface

--- a/rabbitmq/publisher_test.go
+++ b/rabbitmq/publisher_test.go
@@ -2,10 +2,7 @@ package rabbitmq_test
 
 import (
 	"errors"
-	"sync"
-	"sync/atomic"
 	"testing"
-	"time"
 
 	"github.com/multiversx/mx-chain-core-go/core/check"
 	"github.com/multiversx/mx-chain-core-go/core/mock"
@@ -15,7 +12,6 @@ import (
 	"github.com/multiversx/mx-chain-notifier-go/mocks"
 	"github.com/multiversx/mx-chain-notifier-go/rabbitmq"
 	"github.com/streadway/amqp"
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
@@ -180,16 +176,13 @@ func TestRabbitMqPublisher(t *testing.T) {
 	})
 }
 
-func TestBroadcast(t *testing.T) {
+func TestPublish(t *testing.T) {
 	t.Parallel()
 
-	wg := sync.WaitGroup{}
-	numCalls := uint32(0)
-
+	wasCalled := false
 	client := &mocks.RabbitClientStub{
 		PublishCalled: func(exchange, key string, mandatory, immediate bool, msg amqp.Publishing) error {
-			atomic.AddUint32(&numCalls, 1)
-			wg.Done()
+			wasCalled = true
 			return nil
 		},
 	}
@@ -200,27 +193,18 @@ func TestBroadcast(t *testing.T) {
 	rabbitmq, err := rabbitmq.NewRabbitMqPublisher(args)
 	require.Nil(t, err)
 
-	rabbitmq.Run()
-	defer rabbitmq.Close()
-	wg.Add(1)
+	rabbitmq.Publish(data.BlockEvents{})
 
-	rabbitmq.Broadcast(data.BlockEvents{})
-
-	wg.Wait()
-
-	assert.Equal(t, uint32(1), atomic.LoadUint32(&numCalls))
+	require.True(t, wasCalled)
 }
 
-func TestBroadcastRevert(t *testing.T) {
+func TestPublishRevert(t *testing.T) {
 	t.Parallel()
 
-	wg := sync.WaitGroup{}
-	numCalls := uint32(0)
-
+	wasCalled := false
 	client := &mocks.RabbitClientStub{
 		PublishCalled: func(exchange, key string, mandatory, immediate bool, msg amqp.Publishing) error {
-			atomic.AddUint32(&numCalls, 1)
-			wg.Done()
+			wasCalled = true
 			return nil
 		},
 	}
@@ -231,27 +215,18 @@ func TestBroadcastRevert(t *testing.T) {
 	rabbitmq, err := rabbitmq.NewRabbitMqPublisher(args)
 	require.Nil(t, err)
 
-	rabbitmq.Run()
-	defer rabbitmq.Close()
-	wg.Add(1)
+	rabbitmq.PublishRevert(data.RevertBlock{})
 
-	rabbitmq.BroadcastRevert(data.RevertBlock{})
-
-	wg.Wait()
-
-	assert.Equal(t, uint32(1), atomic.LoadUint32(&numCalls))
+	require.True(t, wasCalled)
 }
 
 func TestBroadcastFinalized(t *testing.T) {
 	t.Parallel()
 
-	wg := sync.WaitGroup{}
-	numCalls := uint32(0)
-
+	wasCalled := false
 	client := &mocks.RabbitClientStub{
 		PublishCalled: func(exchange, key string, mandatory, immediate bool, msg amqp.Publishing) error {
-			atomic.AddUint32(&numCalls, 1)
-			wg.Done()
+			wasCalled = true
 			return nil
 		},
 	}
@@ -262,27 +237,18 @@ func TestBroadcastFinalized(t *testing.T) {
 	rabbitmq, err := rabbitmq.NewRabbitMqPublisher(args)
 	require.Nil(t, err)
 
-	rabbitmq.Run()
-	defer rabbitmq.Close()
-	wg.Add(1)
+	rabbitmq.PublishFinalized(data.FinalizedBlock{})
 
-	rabbitmq.BroadcastFinalized(data.FinalizedBlock{})
-
-	wg.Wait()
-
-	assert.Equal(t, uint32(1), atomic.LoadUint32(&numCalls))
+	require.True(t, wasCalled)
 }
 
 func TestBroadcastTxs(t *testing.T) {
 	t.Parallel()
 
-	wg := sync.WaitGroup{}
-	numCalls := uint32(0)
-
+	wasCalled := false
 	client := &mocks.RabbitClientStub{
 		PublishCalled: func(exchange, key string, mandatory, immediate bool, msg amqp.Publishing) error {
-			atomic.AddUint32(&numCalls, 1)
-			wg.Done()
+			wasCalled = true
 			return nil
 		},
 	}
@@ -293,27 +259,18 @@ func TestBroadcastTxs(t *testing.T) {
 	rabbitmq, err := rabbitmq.NewRabbitMqPublisher(args)
 	require.Nil(t, err)
 
-	rabbitmq.Run()
-	defer rabbitmq.Close()
-	wg.Add(1)
+	rabbitmq.PublishTxs(data.BlockTxs{})
 
-	rabbitmq.BroadcastTxs(data.BlockTxs{})
-
-	wg.Wait()
-
-	assert.Equal(t, uint32(1), atomic.LoadUint32(&numCalls))
+	require.True(t, wasCalled)
 }
 
 func TestBroadcastScrs(t *testing.T) {
 	t.Parallel()
 
-	wg := sync.WaitGroup{}
-	numCalls := uint32(0)
-
+	wasCalled := false
 	client := &mocks.RabbitClientStub{
 		PublishCalled: func(exchange, key string, mandatory, immediate bool, msg amqp.Publishing) error {
-			atomic.AddUint32(&numCalls, 1)
-			wg.Done()
+			wasCalled = true
 			return nil
 		},
 	}
@@ -324,25 +281,18 @@ func TestBroadcastScrs(t *testing.T) {
 	rabbitmq, err := rabbitmq.NewRabbitMqPublisher(args)
 	require.Nil(t, err)
 
-	rabbitmq.Run()
-	defer rabbitmq.Close()
-	wg.Add(1)
+	rabbitmq.PublishScrs(data.BlockScrs{})
 
-	rabbitmq.BroadcastScrs(data.BlockScrs{})
-
-	wg.Wait()
-
-	assert.Equal(t, uint32(1), atomic.LoadUint32(&numCalls))
+	require.True(t, wasCalled)
 }
 
 func TestBroadcastBlockEventsWithOrder(t *testing.T) {
 	t.Parallel()
 
-	numCalls := uint32(0)
-
+	wasCalled := false
 	client := &mocks.RabbitClientStub{
 		PublishCalled: func(exchange, key string, mandatory, immediate bool, msg amqp.Publishing) error {
-			atomic.AddUint32(&numCalls, 1)
+			wasCalled = true
 			return nil
 		},
 	}
@@ -353,26 +303,27 @@ func TestBroadcastBlockEventsWithOrder(t *testing.T) {
 	rabbitmq, err := rabbitmq.NewRabbitMqPublisher(args)
 	require.Nil(t, err)
 
-	rabbitmq.Run()
-	defer rabbitmq.Close()
+	rabbitmq.PublishBlockEventsWithOrder(data.BlockEventsWithOrder{})
 
-	rabbitmq.BroadcastBlockEventsWithOrder(data.BlockEventsWithOrder{})
-
-	time.Sleep(time.Millisecond * 200)
-
-	assert.Equal(t, uint32(1), atomic.LoadUint32(&numCalls))
+	require.True(t, wasCalled)
 }
 
 func TestClose(t *testing.T) {
 	t.Parallel()
 
+	wasCalled := false
+	client := &mocks.RabbitClientStub{
+		CloseCalled: func() {
+			wasCalled = true
+		},
+	}
+
 	args := createMockArgsRabbitMqPublisher()
+	args.Client = client
 
 	rabbitmq, err := rabbitmq.NewRabbitMqPublisher(args)
 	require.Nil(t, err)
 
-	rabbitmq.Run()
-
-	err = rabbitmq.Close()
-	require.Nil(t, err)
+	rabbitmq.Close()
+	require.True(t, wasCalled)
 }


### PR DESCRIPTION
Refactor publisher components:
- have a general publisher component that can be use in both WS and rabbitmq integration, in order to reduce the duplicated code