### PR TITLE
Use timestamp as milliseconds in outport structs

### DIFF
--- a/data/block.go
+++ b/data/block.go
@@ -43,6 +43,7 @@ type ArgsSaveBlockData struct {
 	TransactionsPool       *outport.TransactionPool
 	AlteredAccounts        map[string]*alteredAccount.AlteredAccount
 	NumberOfShards         uint32
+	HeaderTimeStampMs      uint64
 }
 
 // OutportBlockDataOld holds the block data that will be received on push events

--- a/data/outport.go
+++ b/data/outport.go
@@ -27,20 +27,22 @@ type Event struct {
 
 // BlockEvents holds events data for a block
 type BlockEvents struct {
-	Hash      string  `json:"hash"`
-	ShardID   uint32  `json:"shardId"`
-	TimeStamp uint64  `json:"timestamp"`
-	Events    []Event `json:"events"`
+	Hash        string  `json:"hash"`
+	ShardID     uint32  `json:"shardId"`
+	TimeStamp   uint64  `json:"timestamp"`
+	TimeStampMs uint64  `json:"timestampMs"`
+	Events      []Event `json:"events"`
 }
 
 // RevertBlock holds revert event data
 type RevertBlock struct {
-	Hash      string `json:"hash"`
-	Nonce     uint64 `json:"nonce"`
-	Round     uint64 `json:"round"`
-	Epoch     uint32 `json:"epoch"`
-	ShardID   uint32 `json:"shardId"`
-	TimeStamp uint64 `json:"timestamp"`
+	Hash        string `json:"hash"`
+	Nonce       uint64 `json:"nonce"`
+	Round       uint64 `json:"round"`
+	Epoch       uint32 `json:"epoch"`
+	ShardID     uint32 `json:"shardId"`
+	TimeStamp   uint64 `json:"timestamp"`
+	TimeStampMs uint64 `json:"timestampMs"`
 }
 
 // FinalizedBlock holds finalized block data
@@ -62,12 +64,13 @@ type BlockScrs struct {
 
 // BlockEventsWithOrder holds the block transactions with order
 type BlockEventsWithOrder struct {
-	Hash      string                      `json:"hash"`
-	ShardID   uint32                      `json:"shardID"`
-	TimeStamp uint64                      `json:"timestamp"`
-	Txs       map[string]*outport.TxInfo  `json:"txs"`
-	Scrs      map[string]*outport.SCRInfo `json:"scrs"`
-	Events    []Event                     `json:"events"`
+	Hash        string                      `json:"hash"`
+	ShardID     uint32                      `json:"shardID"`
+	TimeStamp   uint64                      `json:"timestamp"`
+	TimeStampMs uint64                      `json:"timestampMs"`
+	Txs         map[string]*outport.TxInfo  `json:"txs"`
+	Scrs        map[string]*outport.SCRInfo `json:"scrs"`
+	Events      []Event                     `json:"events"`
 }
 
 // NotifierTransaction defines a wrapper over transaction

--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/google/uuid v1.6.0
 	github.com/gorilla/websocket v1.5.3
 	github.com/multiversx/mx-chain-communication-go v1.1.2-0.20250218164645-1f6964baffbe
-	github.com/multiversx/mx-chain-core-go v1.3.2-0.20250605084648-5cca6e5bed94
+	github.com/multiversx/mx-chain-core-go v1.3.2-0.20250606113953-9e4dc87c16cb
 	github.com/multiversx/mx-chain-logger-go v1.0.16-0.20250218161408-6a0c19d0da48
 	github.com/pelletier/go-toml v1.9.3
 	github.com/prometheus/client_model v0.6.1

--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/google/uuid v1.6.0
 	github.com/gorilla/websocket v1.5.3
 	github.com/multiversx/mx-chain-communication-go v1.1.2-0.20250218164645-1f6964baffbe
-	github.com/multiversx/mx-chain-core-go v1.2.25-0.20250218161123-121084ae9840
+	github.com/multiversx/mx-chain-core-go v1.3.2-0.20250605084648-5cca6e5bed94
 	github.com/multiversx/mx-chain-logger-go v1.0.16-0.20250218161408-6a0c19d0da48
 	github.com/pelletier/go-toml v1.9.3
 	github.com/prometheus/client_model v0.6.1

--- a/go.sum
+++ b/go.sum
@@ -132,6 +132,10 @@ github.com/multiversx/mx-chain-communication-go v1.1.2-0.20250218164645-1f6964ba
 github.com/multiversx/mx-chain-communication-go v1.1.2-0.20250218164645-1f6964baffbe/go.mod h1:Em49dwv2INN13+ledsUYFNxvkdNKxbOgTxXS8gmmHyw=
 github.com/multiversx/mx-chain-core-go v1.2.25-0.20250218161123-121084ae9840 h1:rwIljKJpbNLWNBj/oMdcbCKU910JytOXJoBqDYnfres=
 github.com/multiversx/mx-chain-core-go v1.2.25-0.20250218161123-121084ae9840/go.mod h1:IO+vspNan+gT0WOHnJ95uvWygiziHZvfXpff6KnxV7g=
+github.com/multiversx/mx-chain-core-go v1.3.2-0.20250602142114-cb1013453d39 h1:a+98PN1XXTCYiJEdg7gpqfTOxGuQqvA8H1yglidV/p0=
+github.com/multiversx/mx-chain-core-go v1.3.2-0.20250602142114-cb1013453d39/go.mod h1:IO+vspNan+gT0WOHnJ95uvWygiziHZvfXpff6KnxV7g=
+github.com/multiversx/mx-chain-core-go v1.3.2-0.20250605084648-5cca6e5bed94 h1:GYXGyjf5UPF82jVZBXCI20DTQrNbV+aha4MpY8FpjQw=
+github.com/multiversx/mx-chain-core-go v1.3.2-0.20250605084648-5cca6e5bed94/go.mod h1:IO+vspNan+gT0WOHnJ95uvWygiziHZvfXpff6KnxV7g=
 github.com/multiversx/mx-chain-crypto-go v1.2.13-0.20250218161752-9482d9a22234 h1:NNI7kYxzsq+4mTPSUJo0cK1+iPxjUX+gRJDaBRwEQ7M=
 github.com/multiversx/mx-chain-crypto-go v1.2.13-0.20250218161752-9482d9a22234/go.mod h1:QZAw2bZcOxGQRgYACTrmP8pfTa3NyxENIL+00G6nM5E=
 github.com/multiversx/mx-chain-logger-go v1.0.16-0.20250218161408-6a0c19d0da48 h1:Of8RfTBNqJMvfWrDEpAkCAmNjYciM/Hul+yECQMBSHY=

--- a/go.sum
+++ b/go.sum
@@ -136,6 +136,8 @@ github.com/multiversx/mx-chain-core-go v1.3.2-0.20250602142114-cb1013453d39 h1:a
 github.com/multiversx/mx-chain-core-go v1.3.2-0.20250602142114-cb1013453d39/go.mod h1:IO+vspNan+gT0WOHnJ95uvWygiziHZvfXpff6KnxV7g=
 github.com/multiversx/mx-chain-core-go v1.3.2-0.20250605084648-5cca6e5bed94 h1:GYXGyjf5UPF82jVZBXCI20DTQrNbV+aha4MpY8FpjQw=
 github.com/multiversx/mx-chain-core-go v1.3.2-0.20250605084648-5cca6e5bed94/go.mod h1:IO+vspNan+gT0WOHnJ95uvWygiziHZvfXpff6KnxV7g=
+github.com/multiversx/mx-chain-core-go v1.3.2-0.20250606113953-9e4dc87c16cb h1:orPuViEu3dnElbfp6w2q1iokLQlTueb9akRpxfqe6IU=
+github.com/multiversx/mx-chain-core-go v1.3.2-0.20250606113953-9e4dc87c16cb/go.mod h1:IO+vspNan+gT0WOHnJ95uvWygiziHZvfXpff6KnxV7g=
 github.com/multiversx/mx-chain-crypto-go v1.2.13-0.20250218161752-9482d9a22234 h1:NNI7kYxzsq+4mTPSUJo0cK1+iPxjUX+gRJDaBRwEQ7M=
 github.com/multiversx/mx-chain-crypto-go v1.2.13-0.20250218161752-9482d9a22234/go.mod h1:QZAw2bZcOxGQRgYACTrmP8pfTa3NyxENIL+00G6nM5E=
 github.com/multiversx/mx-chain-logger-go v1.0.16-0.20250218161408-6a0c19d0da48 h1:Of8RfTBNqJMvfWrDEpAkCAmNjYciM/Hul+yECQMBSHY=

--- a/integrationTests/websocket/testNotifierWithWebsockets_test.go
+++ b/integrationTests/websocket/testNotifierWithWebsockets_test.go
@@ -178,6 +178,7 @@ func TestNotifierWithWebsockets_BlockEvents(t *testing.T) {
 			Body: &block.Body{
 				MiniBlocks: make([]*block.MiniBlock, 1),
 			},
+			TimestampMs: 1234000,
 		},
 		HeaderGasConsumption: &outport.HeaderGasConsumption{},
 	}
@@ -661,6 +662,7 @@ func testNotifierWithWebsockets_AllEvents(t *testing.T, observerType string) {
 					&block.MiniBlock{},
 				},
 			},
+			TimestampMs: 1234000,
 		},
 		HeaderGasConsumption: &outport.HeaderGasConsumption{},
 	}

--- a/integrationTests/websocket/testNotifierWithWebsockets_test.go
+++ b/integrationTests/websocket/testNotifierWithWebsockets_test.go
@@ -142,10 +142,11 @@ func TestNotifierWithWebsockets_BlockEvents(t *testing.T) {
 		},
 	}
 	expBlockEvents := &data.BlockEventsWithOrder{
-		Hash:      hex.EncodeToString(headerHash),
-		ShardID:   1,
-		TimeStamp: 1234,
-		Events:    events,
+		Hash:        hex.EncodeToString(headerHash),
+		ShardID:     1,
+		TimeStamp:   1234,
+		TimeStampMs: 1234000,
+		Events:      events,
 	}
 
 	header := &block.HeaderV2{
@@ -619,12 +620,13 @@ func testNotifierWithWebsockets_AllEvents(t *testing.T, observerType string) {
 		},
 	}
 	expBlockEvents := data.BlockEventsWithOrder{
-		Hash:      hex.EncodeToString(blockHash),
-		ShardID:   1,
-		TimeStamp: 1234,
-		Events:    events,
-		Txs:       expTxsWithOrder,
-		Scrs:      expScrsWithOrder,
+		Hash:        hex.EncodeToString(blockHash),
+		ShardID:     1,
+		TimeStamp:   1234,
+		TimeStampMs: 1234000,
+		Events:      events,
+		Txs:         expTxsWithOrder,
+		Scrs:        expScrsWithOrder,
 	}
 
 	header = &block.HeaderV2{

--- a/process/eventsHandler.go
+++ b/process/eventsHandler.go
@@ -93,7 +93,7 @@ func (eh *eventsHandler) HandleSaveBlockEvents(allEvents data.ArgsSaveBlockData)
 	}
 
 	headerTimeStamp := eventsData.Header.GetTimeStamp()
-	headerTimeStampMs := headerTimeStamp * 1000 // TODO: handle this properly in Supernova release
+	headerTimeStampMs := allEvents.HeaderTimeStampMs
 
 	pushEvents := data.BlockEvents{
 		Hash:        eventsData.Hash,

--- a/process/eventsHandler.go
+++ b/process/eventsHandler.go
@@ -88,11 +88,19 @@ func (eh *eventsHandler) HandleSaveBlockEvents(allEvents data.ArgsSaveBlockData)
 		return err
 	}
 
+	if check.IfNil(eventsData.Header) {
+		return ErrNilBlockHeader
+	}
+
+	headerTimeStamp := eventsData.Header.GetTimeStamp()
+	headerTimeStampMs := headerTimeStamp * 1000 // TODO: handle this properly in Supernova release
+
 	pushEvents := data.BlockEvents{
-		Hash:      eventsData.Hash,
-		ShardID:   eventsData.Header.GetShardID(),
-		TimeStamp: eventsData.Header.GetTimeStamp(),
-		Events:    eventsData.LogEvents,
+		Hash:        eventsData.Hash,
+		ShardID:     eventsData.Header.GetShardID(),
+		TimeStamp:   headerTimeStamp,
+		TimeStampMs: headerTimeStampMs,
+		Events:      eventsData.LogEvents,
 	}
 	err = eh.handlePushEvents(pushEvents)
 	if err != nil {
@@ -112,12 +120,13 @@ func (eh *eventsHandler) HandleSaveBlockEvents(allEvents data.ArgsSaveBlockData)
 	eh.handleBlockScrs(scrs)
 
 	txsWithOrder := data.BlockEventsWithOrder{
-		Hash:      eventsData.Hash,
-		ShardID:   eventsData.Header.GetShardID(),
-		TimeStamp: eventsData.Header.GetTimeStamp(),
-		Txs:       eventsData.TxsWithOrder,
-		Scrs:      eventsData.ScrsWithOrder,
-		Events:    eventsData.LogEvents,
+		Hash:        eventsData.Hash,
+		ShardID:     eventsData.Header.GetShardID(),
+		TimeStamp:   headerTimeStamp,
+		TimeStampMs: headerTimeStampMs,
+		Txs:         eventsData.TxsWithOrder,
+		Scrs:        eventsData.ScrsWithOrder,
+		Events:      eventsData.LogEvents,
 	}
 	eh.handleBlockEventsWithOrder(txsWithOrder)
 

--- a/process/preprocess/eventsPreProcessorV1.go
+++ b/process/preprocess/eventsPreProcessorV1.go
@@ -101,13 +101,17 @@ func (d *eventsPreProcessorV1) RevertIndexedBlock(marshalledData []byte) error {
 		return err
 	}
 
+	headerTimeStamp := header.GetTimeStamp()
+	headerTimeStampMs := headerTimeStamp * 1000 // TODO: handle this properly in Supernova release
+
 	revertData := &data.RevertBlock{
-		Hash:      hex.EncodeToString(blockData.GetHeaderHash()),
-		Nonce:     header.GetNonce(),
-		Round:     header.GetRound(),
-		Epoch:     header.GetEpoch(),
-		ShardID:   blockData.GetShardID(),
-		TimeStamp: header.GetTimeStamp(),
+		Hash:        hex.EncodeToString(blockData.GetHeaderHash()),
+		Nonce:       header.GetNonce(),
+		Round:       header.GetRound(),
+		Epoch:       header.GetEpoch(),
+		ShardID:     blockData.GetShardID(),
+		TimeStamp:   headerTimeStamp,
+		TimeStampMs: headerTimeStampMs,
 	}
 
 	d.facade.HandleRevertEvents(*revertData)

--- a/process/preprocess/eventsPreProcessorV1.go
+++ b/process/preprocess/eventsPreProcessorV1.go
@@ -64,6 +64,7 @@ func (d *eventsPreProcessorV1) SaveBlock(marshalledData []byte) error {
 		NumberOfShards:         outportBlock.NumberOfShards,
 		TransactionsPool:       outportBlock.TransactionPool,
 		Header:                 header,
+		HeaderTimeStampMs:      outportBlock.BlockData.GetTimestampMs(),
 	}
 
 	err = d.facade.HandlePushEvents(*saveBlockData)
@@ -102,7 +103,7 @@ func (d *eventsPreProcessorV1) RevertIndexedBlock(marshalledData []byte) error {
 	}
 
 	headerTimeStamp := header.GetTimeStamp()
-	headerTimeStampMs := headerTimeStamp * 1000 // TODO: handle this properly in Supernova release
+	headerTimeStampMs := blockData.GetTimestampMs()
 
 	revertData := &data.RevertBlock{
 		Hash:        hex.EncodeToString(blockData.GetHeaderHash()),

--- a/process/preprocess/eventsPreProcessorV1_test.go
+++ b/process/preprocess/eventsPreProcessorV1_test.go
@@ -162,12 +162,13 @@ func TestPreProcessorV1_RevertIndexerBlock(t *testing.T) {
 		}
 
 		expRevertBlock := data.RevertBlock{
-			Hash:      hex.EncodeToString(headerHash),
-			Nonce:     nonce,
-			Round:     round,
-			Epoch:     epoch,
-			ShardID:   shardID,
-			TimeStamp: timestamp,
+			Hash:        hex.EncodeToString(headerHash),
+			Nonce:       nonce,
+			Round:       round,
+			Epoch:       epoch,
+			ShardID:     shardID,
+			TimeStamp:   timestamp,
+			TimeStampMs: timestamp * 1000,
 		}
 
 		args := createMockEventsDataPreProcessorArgs()

--- a/process/preprocess/eventsPreProcessorV1_test.go
+++ b/process/preprocess/eventsPreProcessorV1_test.go
@@ -159,6 +159,7 @@ func TestPreProcessorV1_RevertIndexerBlock(t *testing.T) {
 			HeaderHash:  headerHash,
 			HeaderType:  "Header",
 			ShardID:     shardID,
+			TimestampMs: timestamp * 1000,
 		}
 
 		expRevertBlock := data.RevertBlock{


### PR DESCRIPTION
It sets a new timestamp field with milliseconds granularity.
This will be useful in preparation for Supernova release, when the transition to sub second finality will happen. This way, integrators will have time to adjust using new timestamp.