### PR TITLE
State accesses per account

### DIFF
--- a/data/block.go
+++ b/data/block.go
@@ -23,15 +23,15 @@ type SaveBlockData struct {
 
 // InterceptorBlockData holds the block data needed for processing
 type InterceptorBlockData struct {
-	Hash          string
-	Body          nodeData.BodyHandler
-	Header        nodeData.HeaderHandler
-	Txs           map[string]*transaction.Transaction
-	TxsWithOrder  map[string]*outport.TxInfo
-	Scrs          map[string]*smartContractResult.SmartContractResult
-	ScrsWithOrder map[string]*outport.SCRInfo
-	LogEvents     []Event
-	StateAccesses map[string]*stateChange.StateAccesses
+	Hash                     string
+	Body                     nodeData.BodyHandler
+	Header                   nodeData.HeaderHandler
+	Txs                      map[string]*transaction.Transaction
+	TxsWithOrder             map[string]*outport.TxInfo
+	Scrs                     map[string]*smartContractResult.SmartContractResult
+	ScrsWithOrder            map[string]*outport.SCRInfo
+	LogEvents                []Event
+	StateAccessesPerAccounts map[string]*stateChange.StateAccesses
 }
 
 // ArgsSaveBlockData holds the block data that will be received on push events

--- a/data/outport.go
+++ b/data/outport.go
@@ -76,8 +76,8 @@ type BlockEventsWithOrder struct {
 
 // BlockStateAccesses holds the block state accesses
 type BlockStateAccesses struct {
-	Hash          string                                `json:"hash"`
-	StateAccesses map[string]*stateChange.StateAccesses `json:"stateAccesses"`
+	Hash                     string                                `json:"hash"`
+	StateAccessesPerAccounts map[string]*stateChange.StateAccesses `json:"stateAccessesPerAccounts"`
 }
 
 // NotifierTransaction defines a wrapper over transaction

--- a/data/outport.go
+++ b/data/outport.go
@@ -77,6 +77,9 @@ type BlockEventsWithOrder struct {
 // BlockStateAccesses holds the block state accesses
 type BlockStateAccesses struct {
 	Hash                     string                                `json:"hash"`
+	ShardID                  uint32                                `json:"shardID"`
+	TimeStampMs              uint64                                `json:"timestampMs"`
+	Nonce                    uint64                                `json:"nonce"`
 	StateAccessesPerAccounts map[string]*stateChange.StateAccesses `json:"stateAccessesPerAccounts"`
 }
 

--- a/integrationTests/rabbitmq/testNotifierWithRabbitMQ_test.go
+++ b/integrationTests/rabbitmq/testNotifierWithRabbitMQ_test.go
@@ -54,7 +54,7 @@ func testNotifierWithRabbitMQ(t *testing.T, observerType string, payloadVersion 
 	go pushEventsRequest(wg, client)
 	go pushRevertRequest(wg, client)
 
-	integrationTests.WaitTimeout(t, wg, time.Second*2)
+	integrationTests.WaitTimeout(t, wg, time.Second*5)
 
 	assert.Equal(t, 3, len(notifier.RedisClient.GetEntries()))
 	assert.Equal(t, 7, len(notifier.RabbitMQClient.GetEntries()))

--- a/integrationTests/rabbitmq/testNotifierWithRabbitMQ_test.go
+++ b/integrationTests/rabbitmq/testNotifierWithRabbitMQ_test.go
@@ -1,6 +1,7 @@
 package rabbitmq
 
 import (
+	"encoding/hex"
 	"encoding/json"
 	"sync"
 	"testing"
@@ -40,6 +41,9 @@ func testNotifierWithRabbitMQ(t *testing.T, observerType string, payloadVersion 
 	client, err := integrationTests.CreateObserverConnector(notifier.Facade, observerType, common.MessageQueuePublisherType, payloadVersion)
 	require.Nil(t, err)
 
+	// wait for components to start
+	time.Sleep(time.Second * 5)
+
 	_ = notifier.Publisher.Run()
 	defer notifier.Publisher.Close()
 
@@ -54,7 +58,7 @@ func testNotifierWithRabbitMQ(t *testing.T, observerType string, payloadVersion 
 	go pushEventsRequest(wg, client)
 	go pushRevertRequest(wg, client)
 
-	integrationTests.WaitTimeout(t, wg, time.Second*5)
+	integrationTests.WaitTimeout(t, wg, time.Second*2)
 
 	assert.Equal(t, 3, len(notifier.RedisClient.GetEntries()))
 	assert.Equal(t, 7, len(notifier.RabbitMQClient.GetEntries()))
@@ -70,7 +74,7 @@ func pushEventsRequest(wg *sync.WaitGroup, webServer integrationTests.ObserverCo
 
 	txPool := &outport.TransactionPool{
 		Transactions: map[string]*outport.TxInfo{
-			"hash1": {
+			hex.EncodeToString([]byte("hash1")): {
 				Transaction: &transaction.Transaction{
 					Nonce: 1,
 				},
@@ -81,7 +85,7 @@ func pushEventsRequest(wg *sync.WaitGroup, webServer integrationTests.ObserverCo
 			},
 		},
 		SmartContractResults: map[string]*outport.SCRInfo{
-			"hash2": {
+			hex.EncodeToString([]byte("hash2")): {
 				SmartContractResult: &smartContractResult.SmartContractResult{
 					Nonce: 2,
 				},

--- a/integrationTests/rabbitmq/testNotifierWithRabbitMQ_test.go
+++ b/integrationTests/rabbitmq/testNotifierWithRabbitMQ_test.go
@@ -130,6 +130,7 @@ func pushEventsRequest(wg *sync.WaitGroup, webServer integrationTests.ObserverCo
 		},
 		TransactionPool:      txPool,
 		HeaderGasConsumption: &outport.HeaderGasConsumption{},
+		StateAccesses:        stateAccesses,
 	}
 
 	err := webServer.PushEventsRequest(saveBlockData)

--- a/integrationTests/websocket/testNotifierWithWebsockets_test.go
+++ b/integrationTests/websocket/testNotifierWithWebsockets_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/multiversx/mx-chain-core-go/data/block"
 	"github.com/multiversx/mx-chain-core-go/data/outport"
 	"github.com/multiversx/mx-chain-core-go/data/smartContractResult"
+	"github.com/multiversx/mx-chain-core-go/data/stateChange"
 	"github.com/multiversx/mx-chain-core-go/data/transaction"
 	"github.com/multiversx/mx-chain-notifier-go/common"
 	"github.com/multiversx/mx-chain-notifier-go/data"
@@ -61,6 +62,22 @@ func TestNotifierWithWebsockets_PushEvents(t *testing.T) {
 		},
 	}
 	headerBytes, _ := json.Marshal(header)
+
+	stateAccesses := make(map[string]*stateChange.StateAccesses)
+	stateAccesses["txHash1"] = &stateChange.StateAccesses{
+		StateAccess: []*stateChange.StateAccess{
+			&stateChange.StateAccess{
+				MainTrieKey: []byte("mainTrieKey1"),
+				MainTrieVal: []byte("mainTrieVal1"),
+			},
+			&stateChange.StateAccess{
+				MainTrieKey: []byte("mainTrieKey2"),
+				MainTrieVal: []byte("mainTrieVal2"),
+			},
+		},
+	}
+	stateAccesses["txHash2"] = &stateChange.StateAccesses{}
+
 	saveBlockData := &outport.OutportBlock{
 		TransactionPool: &outport.TransactionPool{
 			Logs: []*outport.LogData{
@@ -85,6 +102,7 @@ func TestNotifierWithWebsockets_PushEvents(t *testing.T) {
 			},
 		},
 		HeaderGasConsumption: &outport.HeaderGasConsumption{},
+		StateAccesses:        stateAccesses,
 	}
 
 	wg := &sync.WaitGroup{}
@@ -156,6 +174,10 @@ func TestNotifierWithWebsockets_BlockEvents(t *testing.T) {
 		},
 	}
 	headerBytes, _ := json.Marshal(header)
+
+	stateAccesses := make(map[string]*stateChange.StateAccesses)
+	stateAccesses["txHash1"] = &stateChange.StateAccesses{}
+
 	saveBlockData := &outport.OutportBlock{
 		TransactionPool: &outport.TransactionPool{
 			Logs: []*outport.LogData{
@@ -181,6 +203,7 @@ func TestNotifierWithWebsockets_BlockEvents(t *testing.T) {
 			TimestampMs: 1234000,
 		},
 		HeaderGasConsumption: &outport.HeaderGasConsumption{},
+		StateAccesses:        stateAccesses,
 	}
 
 	wg := &sync.WaitGroup{}
@@ -355,6 +378,10 @@ func TestNotifierWithWebsockets_TxsEvents(t *testing.T) {
 		},
 	}
 	headerBytes, _ := json.Marshal(header)
+
+	stateAccesses := make(map[string]*stateChange.StateAccesses)
+	stateAccesses["txHash1"] = &stateChange.StateAccesses{}
+
 	saveBlockData := &outport.OutportBlock{
 		TransactionPool: &outport.TransactionPool{
 			Transactions: txs,
@@ -368,6 +395,7 @@ func TestNotifierWithWebsockets_TxsEvents(t *testing.T) {
 			},
 		},
 		HeaderGasConsumption: &outport.HeaderGasConsumption{},
+		StateAccesses:        stateAccesses,
 	}
 
 	expTxs := map[string]*transaction.Transaction{
@@ -438,6 +466,10 @@ func TestNotifierWithWebsockets_ScrsEvents(t *testing.T) {
 		},
 	}
 	headerBytes, _ := json.Marshal(header)
+
+	stateAccesses := make(map[string]*stateChange.StateAccesses)
+	stateAccesses["txHash1"] = &stateChange.StateAccesses{}
+
 	blockEvents := &outport.OutportBlock{
 		TransactionPool: &outport.TransactionPool{
 			SmartContractResults: scrs,
@@ -451,6 +483,7 @@ func TestNotifierWithWebsockets_ScrsEvents(t *testing.T) {
 			},
 		},
 		HeaderGasConsumption: &outport.HeaderGasConsumption{},
+		StateAccesses:        stateAccesses,
 	}
 
 	expScrs := map[string]*smartContractResult.SmartContractResult{
@@ -637,6 +670,10 @@ func testNotifierWithWebsockets_AllEvents(t *testing.T, observerType string) {
 		},
 	}
 	headerBytes, _ = json.Marshal(header)
+
+	stateAccesses := make(map[string]*stateChange.StateAccesses)
+	stateAccesses["txHash1"] = &stateChange.StateAccesses{}
+
 	blockEvents := &outport.OutportBlock{
 		TransactionPool: &outport.TransactionPool{
 			Transactions:         txs,
@@ -665,6 +702,7 @@ func testNotifierWithWebsockets_AllEvents(t *testing.T, observerType string) {
 			TimestampMs: 1234000,
 		},
 		HeaderGasConsumption: &outport.HeaderGasConsumption{},
+		StateAccesses:        stateAccesses,
 	}
 
 	numEvents := 6

--- a/process/errors.go
+++ b/process/errors.go
@@ -31,3 +31,6 @@ var ErrNilPublisherHandler = errors.New("nil publisher handler provided")
 
 // ErrNilEventsInterceptor signals that a nil events interceptor was provided
 var ErrNilEventsInterceptor = errors.New("nil events interceptor")
+
+// ErrNilStateAccesses signals that a nil state accesses has been provided
+var ErrNilStateAccesses = errors.New("nil state accessess provided")

--- a/process/errors.go
+++ b/process/errors.go
@@ -33,4 +33,4 @@ var ErrNilPublisherHandler = errors.New("nil publisher handler provided")
 var ErrNilEventsInterceptor = errors.New("nil events interceptor")
 
 // ErrNilStateAccesses signals that a nil state accesses has been provided
-var ErrNilStateAccesses = errors.New("nil state accessess provided")
+var ErrNilStateAccesses = errors.New("nil state accesses provided")

--- a/process/eventsHandler.go
+++ b/process/eventsHandler.go
@@ -132,6 +132,9 @@ func (eh *eventsHandler) HandleSaveBlockEvents(allEvents data.ArgsSaveBlockData)
 
 	stateAccesses := data.BlockStateAccesses{
 		Hash:                     eventsData.Hash,
+		ShardID:                  eventsData.Header.GetShardID(),
+		TimeStampMs:              headerTimeStampMs,
+		Nonce:                    eventsData.Header.GetNonce(),
 		StateAccessesPerAccounts: eventsData.StateAccessesPerAccounts,
 	}
 	eh.handleStateAccesses(stateAccesses)

--- a/process/eventsHandler.go
+++ b/process/eventsHandler.go
@@ -131,8 +131,8 @@ func (eh *eventsHandler) HandleSaveBlockEvents(allEvents data.ArgsSaveBlockData)
 	eh.handleBlockEventsWithOrder(txsWithOrder)
 
 	stateAccesses := data.BlockStateAccesses{
-		Hash:          eventsData.Hash,
-		StateAccesses: eventsData.StateAccesses,
+		Hash:                     eventsData.Hash,
+		StateAccessesPerAccounts: eventsData.StateAccessesPerAccounts,
 	}
 	eh.handleStateAccesses(stateAccesses)
 

--- a/process/eventsInterceptor.go
+++ b/process/eventsInterceptor.go
@@ -11,6 +11,7 @@ import (
 	"github.com/multiversx/mx-chain-core-go/data/smartContractResult"
 	"github.com/multiversx/mx-chain-core-go/data/stateChange"
 	"github.com/multiversx/mx-chain-core-go/data/transaction"
+	logger "github.com/multiversx/mx-chain-logger-go"
 	"github.com/multiversx/mx-chain-notifier-go/data"
 )
 
@@ -163,17 +164,13 @@ func (ei *eventsInterceptor) getStateAccessesPerAccounts(eventsData *data.ArgsSa
 
 			// TODO: make sure code update operations are handled properly
 			//	at the moment they are handled as a separate entry
-			// if stateAccess.Operation == stateChange.WriteCode {
-			// 	continue
-			// }
 
 			accKey := hex.EncodeToString(stateAccess.MainTrieKey)
-			acc, ok := stateAccessesPerAccounts[accKey]
+			_, ok := stateAccessesPerAccounts[accKey]
 			if !ok {
-				acc = &stateChange.StateAccesses{
+				stateAccessesPerAccounts[accKey] = &stateChange.StateAccesses{
 					StateAccess: make([]*stateChange.StateAccess, 0),
 				}
-				stateAccessesPerAccounts[accKey] = acc
 			}
 
 			stateAccessesPerAccounts[accKey].StateAccess = append(stateAccessesPerAccounts[accKey].StateAccess, stateAccess)
@@ -188,6 +185,10 @@ func (ei *eventsInterceptor) getStateAccessesPerAccounts(eventsData *data.ArgsSa
 }
 
 func logStateAccessesPerTxs(stateAccesses map[string]*stateChange.StateAccesses) {
+	if log.GetLevel() > logger.LogTrace {
+		return
+	}
+
 	log.Trace("getStateAccessesPerAccounts",
 		"num stateAccessesPerTxs", len(stateAccesses),
 	)

--- a/process/eventsInterceptor.go
+++ b/process/eventsInterceptor.go
@@ -200,7 +200,8 @@ func logStateAccessesPerTxs(stateAccesses map[string]*stateChange.StateAccesses)
 
 		for _, st := range sts.StateAccess {
 			log.Trace("st",
-				"txHash", st.GetTxHash(),
+				"actionType", st.GetType(),
+				"operation", st.GetOperation(),
 			)
 		}
 	}

--- a/process/eventsInterceptor.go
+++ b/process/eventsInterceptor.go
@@ -145,7 +145,13 @@ func (ei *eventsInterceptor) getStateAccessesPerAccounts(eventsData *data.ArgsSa
 
 	stateAccessesPerAccounts := make(map[string]*stateChange.StateAccesses)
 	for _, txInfo := range txsWithOrder {
-		stateAccessesPerTx, ok := stateAccessesPerTxs[txInfo.hash]
+		txHash, err := hex.DecodeString(txInfo.hash)
+		if err != nil {
+			log.Error("failed to decode tx hash", "txHash", txInfo.hash)
+			continue
+		}
+
+		stateAccessesPerTx, ok := stateAccessesPerTxs[string(txHash)]
 		if !ok {
 			log.Warn("did not find state accesses for tx", "txHash", txInfo.hash)
 			continue

--- a/process/eventsInterceptor.go
+++ b/process/eventsInterceptor.go
@@ -59,9 +59,6 @@ func (ei *eventsInterceptor) ProcessBlockEvents(eventsData *data.ArgsSaveBlockDa
 	if eventsData.Header == nil {
 		return nil, ErrNilBlockHeader
 	}
-	if eventsData.StateAccesses == nil {
-		return nil, ErrNilStateAccesses
-	}
 
 	events := ei.getLogEventsFromTransactionsPool(eventsData.TransactionsPool.Logs)
 
@@ -128,6 +125,15 @@ func getTxsWithOrder(transactionsPool *outport.TransactionPool) []txWithOrder {
 }
 
 func (ei *eventsInterceptor) getStateAccessesPerAccounts(eventsData *data.ArgsSaveBlockData) map[string]*stateChange.StateAccesses {
+
+	if eventsData.StateAccesses == nil {
+		log.Warn("getStateAccessesPerAccounts failed: will return empty state accesses per accounts",
+			"error", ErrNilStateAccesses,
+		)
+
+		return make(map[string]*stateChange.StateAccesses)
+	}
+
 	stateAccessesPerTxs := eventsData.StateAccesses
 
 	// txs hashes with order

--- a/process/eventsInterceptor.go
+++ b/process/eventsInterceptor.go
@@ -143,7 +143,7 @@ func (ei *eventsInterceptor) getStateAccessesPerAccounts(eventsData *data.ArgsSa
 
 		for _, stateAccess := range stateAccessesPerTx.StateAccess {
 			if stateAccess.Type == stateChange.Read {
-				// TODO: add a flag here to allow read state accessess
+				// TODO: add a flag here to allow read state accesses
 				continue
 			}
 

--- a/process/eventsInterceptor.go
+++ b/process/eventsInterceptor.go
@@ -2,15 +2,22 @@ package process
 
 import (
 	"encoding/hex"
+	"sort"
 
 	"github.com/multiversx/mx-chain-core-go/core"
 	"github.com/multiversx/mx-chain-core-go/core/check"
 	nodeData "github.com/multiversx/mx-chain-core-go/data"
 	"github.com/multiversx/mx-chain-core-go/data/outport"
 	"github.com/multiversx/mx-chain-core-go/data/smartContractResult"
+	"github.com/multiversx/mx-chain-core-go/data/stateChange"
 	"github.com/multiversx/mx-chain-core-go/data/transaction"
 	"github.com/multiversx/mx-chain-notifier-go/data"
 )
+
+type txWithOrder struct {
+	hash  string
+	index uint32
+}
 
 // logEvent defines a log event associated with corresponding tx hash
 type logEvent struct {
@@ -52,6 +59,9 @@ func (ei *eventsInterceptor) ProcessBlockEvents(eventsData *data.ArgsSaveBlockDa
 	if eventsData.Header == nil {
 		return nil, ErrNilBlockHeader
 	}
+	if eventsData.StateAccesses == nil {
+		return nil, ErrNilStateAccesses
+	}
 
 	events := ei.getLogEventsFromTransactionsPool(eventsData.TransactionsPool.Logs)
 
@@ -67,16 +77,95 @@ func (ei *eventsInterceptor) ProcessBlockEvents(eventsData *data.ArgsSaveBlockDa
 	}
 	scrsWithOrder := eventsData.TransactionsPool.SmartContractResults
 
+	stateAccessesPerAccounts := ei.getStateAccessesPerAccounts(eventsData)
+
 	return &data.InterceptorBlockData{
-		Hash:          hex.EncodeToString(eventsData.HeaderHash),
-		Body:          eventsData.Body,
-		Header:        eventsData.Header,
-		Txs:           txs,
-		TxsWithOrder:  txsWithOrder,
-		Scrs:          scrs,
-		ScrsWithOrder: scrsWithOrder,
-		LogEvents:     events,
+		Hash:                     hex.EncodeToString(eventsData.HeaderHash),
+		Body:                     eventsData.Body,
+		Header:                   eventsData.Header,
+		Txs:                      txs,
+		TxsWithOrder:             txsWithOrder,
+		Scrs:                     scrs,
+		ScrsWithOrder:            scrsWithOrder,
+		LogEvents:                events,
+		StateAccessesPerAccounts: stateAccessesPerAccounts,
 	}, nil
+}
+
+func getTxsWithOrder(transactionsPool *outport.TransactionPool) []txWithOrder {
+	txsWithOrder := make([]txWithOrder, 0)
+
+	for txHash, txInfo := range transactionsPool.Transactions {
+		txsWithOrder = append(txsWithOrder, txWithOrder{
+			hash:  txHash,
+			index: txInfo.ExecutionOrder,
+		})
+	}
+	for txHash, txInfo := range transactionsPool.SmartContractResults {
+		txsWithOrder = append(txsWithOrder, txWithOrder{
+			hash:  txHash,
+			index: txInfo.ExecutionOrder,
+		})
+	}
+	for txHash, txInfo := range transactionsPool.Rewards {
+		txsWithOrder = append(txsWithOrder, txWithOrder{
+			hash:  txHash,
+			index: txInfo.ExecutionOrder,
+		})
+	}
+	for txHash, txInfo := range transactionsPool.InvalidTxs {
+		txsWithOrder = append(txsWithOrder, txWithOrder{
+			hash:  txHash,
+			index: txInfo.ExecutionOrder,
+		})
+	}
+
+	sort.Slice(txsWithOrder, func(i, j int) bool {
+		return txsWithOrder[i].index < txsWithOrder[j].index
+	})
+
+	return txsWithOrder
+}
+
+func (ei *eventsInterceptor) getStateAccessesPerAccounts(eventsData *data.ArgsSaveBlockData) map[string]*stateChange.StateAccesses {
+	stateAccessesPerTxs := eventsData.StateAccesses
+
+	// txs hashes with order
+	txsWithOrder := getTxsWithOrder(eventsData.TransactionsPool)
+
+	stateAccessesPerAccounts := make(map[string]*stateChange.StateAccesses)
+	for _, txInfo := range txsWithOrder {
+		stateAccessesPerTx, ok := stateAccessesPerTxs[txInfo.hash]
+		if !ok {
+			log.Warn("did not find state accesses for tx", "txHash", txInfo.hash)
+			continue
+		}
+
+		for _, stateAccess := range stateAccessesPerTx.StateAccess {
+			if stateAccess.Type == stateChange.Read {
+				// TODO: add a flag here to allow read state accessess
+				continue
+			}
+
+			if stateAccess.Operation == stateChange.WriteCode {
+				// TODO: handle code update operations
+				continue
+			}
+
+			accKey := hex.EncodeToString(stateAccess.MainTrieKey)
+			acc, ok := stateAccessesPerAccounts[accKey]
+			if !ok {
+				acc = &stateChange.StateAccesses{
+					StateAccess: make([]*stateChange.StateAccess, 0),
+				}
+				stateAccessesPerAccounts[accKey] = acc
+			}
+
+			stateAccessesPerAccounts[accKey].StateAccess = append(stateAccessesPerAccounts[accKey].StateAccess, stateAccess)
+		}
+	}
+
+	return stateAccessesPerAccounts
 }
 
 func (ei *eventsInterceptor) getLogEventsFromTransactionsPool(logs []*outport.LogData) []data.Event {

--- a/process/eventsInterceptor.go
+++ b/process/eventsInterceptor.go
@@ -136,6 +136,10 @@ func (ei *eventsInterceptor) getStateAccessesPerAccounts(eventsData *data.ArgsSa
 
 	stateAccessesPerTxs := eventsData.StateAccesses
 
+	log.Debug("getStateAccessesPerAccounts",
+		"num stateAccessesPerTxs", len(stateAccessesPerTxs),
+	)
+
 	// txs hashes with order
 	txsWithOrder := getTxsWithOrder(eventsData.TransactionsPool)
 
@@ -171,6 +175,10 @@ func (ei *eventsInterceptor) getStateAccessesPerAccounts(eventsData *data.ArgsSa
 			stateAccessesPerAccounts[accKey].StateAccess = append(stateAccessesPerAccounts[accKey].StateAccess, stateAccess)
 		}
 	}
+
+	log.Debug("getStateAccessesPerAccounts",
+		"num stateAccessesPerAccounts", len(stateAccessesPerAccounts),
+	)
 
 	return stateAccessesPerAccounts
 }

--- a/process/eventsInterceptor.go
+++ b/process/eventsInterceptor.go
@@ -147,10 +147,11 @@ func (ei *eventsInterceptor) getStateAccessesPerAccounts(eventsData *data.ArgsSa
 				continue
 			}
 
-			if stateAccess.Operation == stateChange.WriteCode {
-				// TODO: handle code update operations
-				continue
-			}
+			// TODO: make sure code update operations are handled properly
+			//	at the moment they are handled as a separate entry
+			// if stateAccess.Operation == stateChange.WriteCode {
+			// 	continue
+			// }
 
 			accKey := hex.EncodeToString(stateAccess.MainTrieKey)
 			acc, ok := stateAccessesPerAccounts[accKey]

--- a/process/eventsInterceptor.go
+++ b/process/eventsInterceptor.go
@@ -125,9 +125,9 @@ func getTxsWithOrder(transactionsPool *outport.TransactionPool) []txWithOrder {
 }
 
 func (ei *eventsInterceptor) getStateAccessesPerAccounts(eventsData *data.ArgsSaveBlockData) map[string]*stateChange.StateAccesses {
-
 	if eventsData.StateAccesses == nil {
 		log.Warn("getStateAccessesPerAccounts failed: will return empty state accesses per accounts",
+			"block hash", eventsData.HeaderHash,
 			"error", ErrNilStateAccesses,
 		)
 
@@ -136,9 +136,7 @@ func (ei *eventsInterceptor) getStateAccessesPerAccounts(eventsData *data.ArgsSa
 
 	stateAccessesPerTxs := eventsData.StateAccesses
 
-	log.Debug("getStateAccessesPerAccounts",
-		"num stateAccessesPerTxs", len(stateAccessesPerTxs),
-	)
+	logStateAccessesPerTxs(stateAccessesPerTxs)
 
 	// txs hashes with order
 	txsWithOrder := getTxsWithOrder(eventsData.TransactionsPool)
@@ -182,11 +180,29 @@ func (ei *eventsInterceptor) getStateAccessesPerAccounts(eventsData *data.ArgsSa
 		}
 	}
 
-	log.Debug("getStateAccessesPerAccounts",
+	log.Trace("getStateAccessesPerAccounts",
 		"num stateAccessesPerAccounts", len(stateAccessesPerAccounts),
 	)
 
 	return stateAccessesPerAccounts
+}
+
+func logStateAccessesPerTxs(stateAccesses map[string]*stateChange.StateAccesses) {
+	log.Trace("getStateAccessesPerAccounts",
+		"num stateAccessesPerTxs", len(stateAccesses),
+	)
+
+	for txHash, sts := range stateAccesses {
+		log.Trace("stateAccessesPerTx",
+			"txHash", txHash,
+		)
+
+		for _, st := range sts.StateAccess {
+			log.Trace("st",
+				"txHash", st.GetTxHash(),
+			)
+		}
+	}
 }
 
 func (ei *eventsInterceptor) getLogEventsFromTransactionsPool(logs []*outport.LogData) []data.Event {

--- a/process/eventsInterceptor_test.go
+++ b/process/eventsInterceptor_test.go
@@ -102,7 +102,7 @@ func TestProcessBlockEvents(t *testing.T) {
 		require.Equal(t, process.ErrNilBlockHeader, err)
 	})
 
-	t.Run("nil state accesses", func(t *testing.T) {
+	t.Run("nil state accesses, should return empty map", func(t *testing.T) {
 		t.Parallel()
 
 		eventsInterceptor, _ := process.NewEventsInterceptor(createMockEventsInterceptorArgs())
@@ -115,8 +115,21 @@ func TestProcessBlockEvents(t *testing.T) {
 			StateAccesses:    nil,
 		}
 		events, err := eventsInterceptor.ProcessBlockEvents(eventsData)
-		require.Nil(t, events)
-		require.Equal(t, process.ErrNilStateAccesses, err)
+		require.Nil(t, err)
+
+		expInterceptorData := &data.InterceptorBlockData{
+			Hash:                     hex.EncodeToString([]byte("headerHash")),
+			Body:                     &block.Body{},
+			Header:                   &block.HeaderV2{},
+			Txs:                      map[string]*transaction.Transaction{},
+			TxsWithOrder:             map[string]*outport.TxInfo(nil),
+			Scrs:                     map[string]*smartContractResult.SmartContractResult{},
+			ScrsWithOrder:            map[string]*outport.SCRInfo(nil),
+			LogEvents:                []data.Event{},
+			StateAccessesPerAccounts: map[string]*stateChange.StateAccesses{},
+		}
+
+		require.Equal(t, expInterceptorData, events)
 	})
 
 	t.Run("should work", func(t *testing.T) {
@@ -361,7 +374,7 @@ func TestEventsInterceptor_GetStateAccessesPerAccounts(t *testing.T) {
 	en, _ := process.NewEventsInterceptor(args)
 
 	txs := map[string]*outport.TxInfo{
-		"txHash1": {
+		hex.EncodeToString([]byte("txHash1")): {
 			Transaction: &transaction.Transaction{
 				Nonce: 2,
 			},
@@ -369,7 +382,7 @@ func TestEventsInterceptor_GetStateAccessesPerAccounts(t *testing.T) {
 		},
 	}
 	scrs := map[string]*outport.SCRInfo{
-		"txHash2": {
+		hex.EncodeToString([]byte("txHash2")): {
 			SmartContractResult: &smartContractResult.SmartContractResult{
 				Nonce: 3,
 			},
@@ -377,7 +390,7 @@ func TestEventsInterceptor_GetStateAccessesPerAccounts(t *testing.T) {
 		},
 	}
 	invalidTxs := map[string]*outport.TxInfo{
-		"txHash0": {
+		hex.EncodeToString([]byte("txHash0")): {
 			Transaction: &transaction.Transaction{
 				Nonce: 1,
 			},

--- a/process/eventsInterceptor_test.go
+++ b/process/eventsInterceptor_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/multiversx/mx-chain-core-go/data/block"
 	"github.com/multiversx/mx-chain-core-go/data/outport"
 	"github.com/multiversx/mx-chain-core-go/data/smartContractResult"
+	"github.com/multiversx/mx-chain-core-go/data/stateChange"
 	"github.com/multiversx/mx-chain-core-go/data/transaction"
 	"github.com/multiversx/mx-chain-notifier-go/data"
 	"github.com/multiversx/mx-chain-notifier-go/mocks"
@@ -101,6 +102,23 @@ func TestProcessBlockEvents(t *testing.T) {
 		require.Equal(t, process.ErrNilBlockHeader, err)
 	})
 
+	t.Run("nil state accesses", func(t *testing.T) {
+		t.Parallel()
+
+		eventsInterceptor, _ := process.NewEventsInterceptor(createMockEventsInterceptorArgs())
+
+		eventsData := &data.ArgsSaveBlockData{
+			HeaderHash:       []byte("headerHash"),
+			TransactionsPool: &outport.TransactionPool{},
+			Body:             &block.Body{},
+			Header:           &block.HeaderV2{},
+			StateAccesses:    nil,
+		}
+		events, err := eventsInterceptor.ProcessBlockEvents(eventsData)
+		require.Nil(t, events)
+		require.Equal(t, process.ErrNilStateAccesses, err)
+	})
+
 	t.Run("should work", func(t *testing.T) {
 		t.Parallel()
 
@@ -157,6 +175,7 @@ func TestProcessBlockEvents(t *testing.T) {
 				SmartContractResults: scrs,
 				Logs:                 logs,
 			},
+			StateAccesses: make(map[string]*stateChange.StateAccesses),
 		}
 
 		expTxs := map[string]*transaction.Transaction{
@@ -202,6 +221,7 @@ func TestProcessBlockEvents(t *testing.T) {
 					Topics:     make([][]byte, 0),
 				},
 			},
+			StateAccessesPerAccounts: make(map[string]*stateChange.StateAccesses),
 		}
 
 		events, err := eventsInterceptor.ProcessBlockEvents(&blockEvents)
@@ -250,6 +270,7 @@ func TestProcessBlockEvents(t *testing.T) {
 			TransactionsPool: &outport.TransactionPool{
 				Logs: logs,
 			},
+			StateAccesses: make(map[string]*stateChange.StateAccesses),
 		}
 
 		expEvents := &data.InterceptorBlockData{
@@ -266,6 +287,7 @@ func TestProcessBlockEvents(t *testing.T) {
 					Topics:     make([][]byte, 0),
 				},
 			},
+			StateAccessesPerAccounts: make(map[string]*stateChange.StateAccesses),
 		}
 
 		events, err := eventsInterceptor.ProcessBlockEvents(&blockEvents)
@@ -330,4 +352,241 @@ func TestGetLogEventsFromTransactionsPool(t *testing.T) {
 	require.Equal(t, txHash1, receivedEvents[0].TxHash)
 	require.Equal(t, txHash1, receivedEvents[1].TxHash)
 	require.Equal(t, txHash2, receivedEvents[2].TxHash)
+}
+
+func TestEventsInterceptor_GetStateAccessesPerAccounts(t *testing.T) {
+	t.Parallel()
+
+	args := createMockEventsInterceptorArgs()
+	en, _ := process.NewEventsInterceptor(args)
+
+	txs := map[string]*outport.TxInfo{
+		"txHash1": {
+			Transaction: &transaction.Transaction{
+				Nonce: 2,
+			},
+			ExecutionOrder: 1,
+		},
+	}
+	scrs := map[string]*outport.SCRInfo{
+		"txHash2": {
+			SmartContractResult: &smartContractResult.SmartContractResult{
+				Nonce: 3,
+			},
+			ExecutionOrder: 2,
+		},
+	}
+	invalidTxs := map[string]*outport.TxInfo{
+		"txHash0": {
+			Transaction: &transaction.Transaction{
+				Nonce: 1,
+			},
+			ExecutionOrder: 0,
+		},
+	}
+
+	blockHash := []byte("blockHash")
+
+	t.Run("with write operations", func(t *testing.T) {
+		t.Parallel()
+
+		stateAccesses := make(map[string]*stateChange.StateAccesses)
+		stateAccesses["txHash1"] = &stateChange.StateAccesses{
+			StateAccess: []*stateChange.StateAccess{
+				&stateChange.StateAccess{
+					Type:        stateChange.Write,
+					MainTrieKey: []byte("mainTrieKey1"),
+					MainTrieVal: []byte("mainTrieVal1"),
+				},
+				&stateChange.StateAccess{
+					Type:        stateChange.Write,
+					MainTrieKey: []byte("mainTrieKey2"),
+					MainTrieVal: []byte("mainTrieVal2"),
+				},
+			},
+		}
+		stateAccesses["txHash2"] = &stateChange.StateAccesses{}
+		stateAccesses["txHash0"] = &stateChange.StateAccesses{
+			StateAccess: []*stateChange.StateAccess{
+				&stateChange.StateAccess{
+					Type:        stateChange.Write,
+					MainTrieKey: []byte("mainTrieKey3"),
+					MainTrieVal: []byte("mainTrieVal3"),
+				},
+				&stateChange.StateAccess{
+					Type:        stateChange.Write,
+					MainTrieKey: []byte("mainTrieKey2"),
+					MainTrieVal: []byte("mainTrieVal4"),
+				},
+			},
+		}
+
+		blockEvents := &data.ArgsSaveBlockData{
+			HeaderHash: blockHash,
+			TransactionsPool: &outport.TransactionPool{
+				Transactions:         txs,
+				SmartContractResults: scrs,
+				InvalidTxs:           invalidTxs,
+			},
+			StateAccesses: stateAccesses,
+		}
+
+		expStateAccessesPerAccounts := make(map[string]*stateChange.StateAccesses)
+		expStateAccessesPerAccounts[hex.EncodeToString([]byte("mainTrieKey1"))] = &stateChange.StateAccesses{
+			StateAccess: []*stateChange.StateAccess{
+				&stateChange.StateAccess{
+					Type:        stateChange.Write,
+					MainTrieKey: []byte("mainTrieKey1"),
+					MainTrieVal: []byte("mainTrieVal1"),
+				},
+			},
+		}
+		expStateAccessesPerAccounts[hex.EncodeToString([]byte("mainTrieKey2"))] = &stateChange.StateAccesses{
+			StateAccess: []*stateChange.StateAccess{
+				&stateChange.StateAccess{
+					Type:        stateChange.Write,
+					MainTrieKey: []byte("mainTrieKey2"),
+					MainTrieVal: []byte("mainTrieVal4"),
+				},
+				&stateChange.StateAccess{
+					Type:        stateChange.Write,
+					MainTrieKey: []byte("mainTrieKey2"),
+					MainTrieVal: []byte("mainTrieVal2"),
+				},
+			},
+		}
+		expStateAccessesPerAccounts[hex.EncodeToString([]byte("mainTrieKey3"))] = &stateChange.StateAccesses{
+			StateAccess: []*stateChange.StateAccess{
+				&stateChange.StateAccess{
+					Type:        stateChange.Write,
+					MainTrieKey: []byte("mainTrieKey3"),
+					MainTrieVal: []byte("mainTrieVal3"),
+				},
+			},
+		}
+
+		stateAccessesPerAccounts := en.GetStateAccessesPerAccounts(blockEvents)
+
+		require.Equal(t, expStateAccessesPerAccounts, stateAccessesPerAccounts)
+	})
+
+	t.Run("with read operations", func(t *testing.T) {
+		t.Parallel()
+
+		stateAccesses := make(map[string]*stateChange.StateAccesses)
+		stateAccesses["txHash1"] = &stateChange.StateAccesses{
+			StateAccess: []*stateChange.StateAccess{
+				&stateChange.StateAccess{
+					Type:        stateChange.Read,
+					MainTrieKey: []byte("mainTrieKey1"),
+					MainTrieVal: []byte("mainTrieVal1"),
+				},
+				&stateChange.StateAccess{
+					Type:        stateChange.Read,
+					MainTrieKey: []byte("mainTrieKey2"),
+					MainTrieVal: []byte("mainTrieVal2"),
+				},
+			},
+		}
+		stateAccesses["txHash2"] = &stateChange.StateAccesses{}
+		stateAccesses["txHash0"] = &stateChange.StateAccesses{
+			StateAccess: []*stateChange.StateAccess{
+				&stateChange.StateAccess{
+					Type:        stateChange.Read,
+					MainTrieKey: []byte("mainTrieKey3"),
+					MainTrieVal: []byte("mainTrieVal3"),
+				},
+				&stateChange.StateAccess{
+					Type:        stateChange.Read,
+					MainTrieKey: []byte("mainTrieKey2"),
+					MainTrieVal: []byte("mainTrieVal4"),
+				},
+			},
+		}
+
+		blockEvents := &data.ArgsSaveBlockData{
+			HeaderHash: blockHash,
+			TransactionsPool: &outport.TransactionPool{
+				Transactions:         txs,
+				SmartContractResults: scrs,
+				InvalidTxs:           invalidTxs,
+			},
+			StateAccesses: stateAccesses,
+		}
+
+		expStateAccessesPerAccounts := make(map[string]*stateChange.StateAccesses)
+
+		stateAccessesPerAccounts := en.GetStateAccessesPerAccounts(blockEvents)
+
+		require.Equal(t, expStateAccessesPerAccounts, stateAccessesPerAccounts)
+	})
+
+	t.Run("with read and write operations", func(t *testing.T) {
+		t.Parallel()
+
+		stateAccesses := make(map[string]*stateChange.StateAccesses)
+		stateAccesses["txHash1"] = &stateChange.StateAccesses{
+			StateAccess: []*stateChange.StateAccess{
+				&stateChange.StateAccess{
+					Type:        stateChange.Read,
+					MainTrieKey: []byte("mainTrieKey1"),
+					MainTrieVal: []byte("mainTrieVal1"),
+				},
+				&stateChange.StateAccess{
+					Type:        stateChange.Write,
+					MainTrieKey: []byte("mainTrieKey2"),
+					MainTrieVal: []byte("mainTrieVal2"),
+				},
+			},
+		}
+		stateAccesses["txHash2"] = &stateChange.StateAccesses{}
+		stateAccesses["txHash0"] = &stateChange.StateAccesses{
+			StateAccess: []*stateChange.StateAccess{
+				&stateChange.StateAccess{
+					Type:        stateChange.Write,
+					MainTrieKey: []byte("mainTrieKey3"),
+					MainTrieVal: []byte("mainTrieVal3"),
+				},
+				&stateChange.StateAccess{
+					Type:        stateChange.Read,
+					MainTrieKey: []byte("mainTrieKey2"),
+					MainTrieVal: []byte("mainTrieVal4"),
+				},
+			},
+		}
+
+		blockEvents := &data.ArgsSaveBlockData{
+			HeaderHash: blockHash,
+			TransactionsPool: &outport.TransactionPool{
+				Transactions:         txs,
+				SmartContractResults: scrs,
+				InvalidTxs:           invalidTxs,
+			},
+			StateAccesses: stateAccesses,
+		}
+
+		expStateAccessesPerAccounts := make(map[string]*stateChange.StateAccesses)
+		expStateAccessesPerAccounts[hex.EncodeToString([]byte("mainTrieKey2"))] = &stateChange.StateAccesses{
+			StateAccess: []*stateChange.StateAccess{
+				&stateChange.StateAccess{
+					Type:        stateChange.Write,
+					MainTrieKey: []byte("mainTrieKey2"),
+					MainTrieVal: []byte("mainTrieVal2"),
+				},
+			},
+		}
+		expStateAccessesPerAccounts[hex.EncodeToString([]byte("mainTrieKey3"))] = &stateChange.StateAccesses{
+			StateAccess: []*stateChange.StateAccess{
+				&stateChange.StateAccess{
+					Type:        stateChange.Write,
+					MainTrieKey: []byte("mainTrieKey3"),
+					MainTrieVal: []byte("mainTrieVal3"),
+				},
+			},
+		}
+
+		stateAccessesPerAccounts := en.GetStateAccessesPerAccounts(blockEvents)
+
+		require.Equal(t, expStateAccessesPerAccounts, stateAccessesPerAccounts)
+	})
 }

--- a/process/export_test.go
+++ b/process/export_test.go
@@ -2,6 +2,7 @@ package process
 
 import (
 	"github.com/multiversx/mx-chain-core-go/data/outport"
+	"github.com/multiversx/mx-chain-core-go/data/stateChange"
 	"github.com/multiversx/mx-chain-notifier-go/data"
 )
 
@@ -38,4 +39,9 @@ func (eh *eventsHandler) ShouldProcessSaveBlockEvents(blockHash string) bool {
 // GetLogEventsFromTransactionsPool exports internal method for testing
 func (ei *eventsInterceptor) GetLogEventsFromTransactionsPool(logs []*outport.LogData) []data.Event {
 	return ei.getLogEventsFromTransactionsPool(logs)
+}
+
+// GetStateAccessesPerAccounts -
+func (ei *eventsInterceptor) GetStateAccessesPerAccounts(eventsData *data.ArgsSaveBlockData) map[string]*stateChange.StateAccesses {
+	return ei.getStateAccessesPerAccounts(eventsData)
 }

--- a/testdata/testData.go
+++ b/testdata/testData.go
@@ -5,6 +5,7 @@ import (
 	"github.com/multiversx/mx-chain-core-go/data/block"
 	"github.com/multiversx/mx-chain-core-go/data/outport"
 	"github.com/multiversx/mx-chain-core-go/data/smartContractResult"
+	"github.com/multiversx/mx-chain-core-go/data/stateChange"
 	"github.com/multiversx/mx-chain-core-go/data/transaction"
 	"github.com/multiversx/mx-chain-core-go/marshal"
 	"github.com/multiversx/mx-chain-notifier-go/common"
@@ -115,6 +116,21 @@ func (bd *blockData) OutportBlockV1() *outport.OutportBlock {
 	}
 	headerBytes, _ := bd.marshaller.Marshal(header)
 
+	stateAccesses := make(map[string]*stateChange.StateAccesses)
+	stateAccesses["txHash1"] = &stateChange.StateAccesses{
+		StateAccess: []*stateChange.StateAccess{
+			&stateChange.StateAccess{
+				MainTrieKey: []byte("mainTrieKey1"),
+				MainTrieVal: []byte("mainTrieVal1"),
+			},
+			&stateChange.StateAccess{
+				MainTrieKey: []byte("mainTrieKey2"),
+				MainTrieVal: []byte("mainTrieVal2"),
+			},
+		},
+	}
+	stateAccesses["txHash2"] = &stateChange.StateAccesses{}
+
 	return &outport.OutportBlock{
 		BlockData: &outport.BlockData{
 			HeaderBytes: headerBytes,
@@ -169,6 +185,7 @@ func (bd *blockData) OutportBlockV1() *outport.OutportBlock {
 				},
 			},
 		},
+		StateAccesses:  stateAccesses,
 		NumberOfShards: 2,
 	}
 }


### PR DESCRIPTION
Observer nodes pushes state accesses per transactions via outport driver, and we need state accesses per accounts, for a particular block.

These changes will re-structure state accesses per accounts and pushed them to publishers (rabbitmq, websocket).