### PR TITLE
State accesses backwards compatible

### DIFF
--- a/data/block.go
+++ b/data/block.go
@@ -66,6 +66,7 @@ type OutportBlockDataOld struct {
 	AlteredAccounts        map[string]*alteredAccount.AlteredAccount
 	NumberOfShards         uint32
 	IsImportDB             bool
+	StateAccesses          map[string]*stateChange.StateAccesses
 }
 
 // ArgsSaveBlock holds block data with header type

--- a/data/block.go
+++ b/data/block.go
@@ -48,7 +48,8 @@ type ArgsSaveBlockData struct {
 	AlteredAccounts        map[string]*alteredAccount.AlteredAccount
 	NumberOfShards         uint32
 	HeaderTimeStampMs      uint64
-	StateAccesses          map[string]*outport.StateAccessesForBlock
+	StateAccesses          map[string]*stateChange.StateAccesses
+	StateAccessesForBlock  map[string]*outport.StateAccessesForBlock
 	Results                map[string]*outport.ExecutionResultData
 }
 

--- a/process/eventsInterceptor.go
+++ b/process/eventsInterceptor.go
@@ -123,7 +123,7 @@ func (ei *eventsInterceptor) ProcessBlockEventsV3(eventsData *data.ArgsSaveBlock
 
 		events := ei.getLogEventsFromTransactionsPool(transactionsPool.GetLogs())
 
-		stateAccessesPerAccounts := ei.getStateAccessesPerAccounts(eventsData, headerHash, transactionsPool)
+		stateAccessesPerAccounts := ei.getStateAccessesPerAccountsV3(eventsData, headerHash, transactionsPool)
 
 		blockData := &data.InterceptorBlockData{
 			Hash:                     headerHash,
@@ -210,24 +210,49 @@ func (ei *eventsInterceptor) getStateAccessesPerAccounts(
 		return make(map[string]*stateChange.StateAccesses)
 	}
 
-	stateAccessesPerAccounts := make(map[string]*stateChange.StateAccesses)
-	stateAccessesPerTxs, ok := eventsData.StateAccesses[headerHash]
+	stateAccesses := eventsData.StateAccesses
+
+	return ei.fetchStateAccessesPerAccounts(stateAccesses, transactionPool)
+}
+
+func (ei *eventsInterceptor) getStateAccessesPerAccountsV3(
+	eventsData *data.ArgsSaveBlockData,
+	headerHash string,
+	transactionPool *outport.TransactionPool,
+) map[string]*stateChange.StateAccesses {
+	stateAccessesPerBlock, ok := eventsData.StateAccessesForBlock[headerHash]
 	if !ok {
-		log.Debug("getStateAccessesPerAccounts failed: will return empty state accesses per accounts",
+		log.Debug("stateAccessesPerBlock failed: will return empty state accesses per accounts",
 			"block hash", headerHash,
 		)
-		return stateAccessesPerAccounts
+
+		return make(map[string]*stateChange.StateAccesses)
 	}
 
-	if stateAccessesPerTxs == nil {
-		log.Debug("stateAccessesPerTxs failed: will return empty state accesses per accounts",
+	if stateAccessesPerBlock == nil {
+		log.Debug("stateAccessesPerBlock failed: will return empty state accesses per accounts",
 			"block hash", headerHash,
 			"num state accesses", len(eventsData.StateAccesses),
 		)
-		return stateAccessesPerAccounts
+
+		return make(map[string]*stateChange.StateAccesses)
 	}
 
-	stateAccesses := stateAccessesPerTxs.StateAccesses
+	stateAccesses := stateAccessesPerBlock.StateAccesses
+
+	return ei.fetchStateAccessesPerAccounts(stateAccesses, transactionPool)
+}
+
+func (ei *eventsInterceptor) fetchStateAccessesPerAccounts(
+	stateAccesses map[string]*stateChange.StateAccesses,
+	transactionPool *outport.TransactionPool,
+) map[string]*stateChange.StateAccesses {
+	if stateAccesses == nil {
+		return make(map[string]*stateChange.StateAccesses)
+	}
+
+	stateAccessesPerAccounts := make(map[string]*stateChange.StateAccesses)
+
 	logStateAccessesPerTxs(stateAccesses)
 
 	// txs hashes with order

--- a/process/eventsInterceptor.go
+++ b/process/eventsInterceptor.go
@@ -232,7 +232,7 @@ func (ei *eventsInterceptor) getStateAccessesPerAccountsV3(
 	if stateAccessesPerBlock == nil {
 		log.Debug("stateAccessesPerBlock failed: will return empty state accesses per accounts",
 			"block hash", headerHash,
-			"num state accesses", len(eventsData.StateAccesses),
+			"num state accesses for block", len(eventsData.StateAccessesForBlock),
 		)
 
 		return make(map[string]*stateChange.StateAccesses)

--- a/process/eventsInterceptor_test.go
+++ b/process/eventsInterceptor_test.go
@@ -171,7 +171,8 @@ func TestProcessBlockEvents_WithoutExecutionResults(t *testing.T) {
 				SmartContractResults: scrs,
 				Logs:                 logs,
 			},
-			StateAccesses: make(map[string]*outport.StateAccessesForBlock),
+			StateAccesses:         make(map[string]*stateChange.StateAccesses),
+			StateAccessesForBlock: make(map[string]*outport.StateAccessesForBlock),
 		}
 
 		expTxs := map[string]*transaction.Transaction{
@@ -266,7 +267,8 @@ func TestProcessBlockEvents_WithoutExecutionResults(t *testing.T) {
 			TransactionsPool: &outport.TransactionPool{
 				Logs: logs,
 			},
-			StateAccesses: make(map[string]*outport.StateAccessesForBlock),
+			StateAccesses:         make(map[string]*stateChange.StateAccesses),
+			StateAccessesForBlock: make(map[string]*outport.StateAccessesForBlock),
 		}
 
 		expEvents := &data.InterceptorBlockData{
@@ -363,12 +365,13 @@ func TestProcessBlockEvents_WithExecutionResults(t *testing.T) {
 		}
 
 		blockEvents := data.ArgsSaveBlockData{
-			HeaderHash:       blockHash,
-			Body:             blockBody,
-			Header:           blockHeader,
-			TransactionsPool: proposedTxPool,
-			StateAccesses:    make(map[string]*outport.StateAccessesForBlock),
-			Results:          execResults,
+			HeaderHash:            blockHash,
+			Body:                  blockBody,
+			Header:                blockHeader,
+			TransactionsPool:      proposedTxPool,
+			StateAccesses:         make(map[string]*stateChange.StateAccesses),
+			StateAccessesForBlock: make(map[string]*outport.StateAccessesForBlock),
+			Results:               execResults,
 		}
 
 		expTxs := map[string]*transaction.Transaction{
@@ -473,12 +476,13 @@ func TestProcessBlockEvents_WithExecutionResults(t *testing.T) {
 		}
 
 		blockEvents := data.ArgsSaveBlockData{
-			HeaderHash:       blockHash,
-			Body:             blockBody,
-			Header:           blockHeader,
-			TransactionsPool: proposedTxPool,
-			StateAccesses:    make(map[string]*outport.StateAccessesForBlock),
-			Results:          execResults,
+			HeaderHash:            blockHash,
+			Body:                  blockBody,
+			Header:                blockHeader,
+			TransactionsPool:      proposedTxPool,
+			StateAccesses:         make(map[string]*stateChange.StateAccesses),
+			StateAccessesForBlock: make(map[string]*outport.StateAccessesForBlock),
+			Results:               execResults,
 		}
 
 		expEvents := []*data.InterceptorBlockData{
@@ -563,7 +567,7 @@ func TestGetLogEventsFromTransactionsPool(t *testing.T) {
 	require.Equal(t, txHash2, receivedEvents[2].TxHash)
 }
 
-func TestEventsInterceptor_GetStateAccessesPerAccounts(t *testing.T) {
+func TestEventsInterceptor_GetStateAccessesPerAccountsV3(t *testing.T) {
 	t.Parallel()
 
 	txs := map[string]*outport.TxInfo{
@@ -686,6 +690,8 @@ func TestEventsInterceptor_GetStateAccessesPerAccounts(t *testing.T) {
 
 	blockHash := []byte("blockHash")
 
+	// before header V3
+
 	t.Run("with write operations", func(t *testing.T) {
 		t.Parallel()
 
@@ -727,9 +733,7 @@ func TestEventsInterceptor_GetStateAccessesPerAccounts(t *testing.T) {
 				SmartContractResults: scrs,
 				InvalidTxs:           invalidTxs,
 			},
-			StateAccesses: map[string]*outport.StateAccessesForBlock{
-				hex.EncodeToString(blockHash): {stateAccesses},
-			},
+			StateAccesses: stateAccesses,
 		}
 
 		expStateAccessesPerAccounts := make(map[string]*stateChange.StateAccesses)
@@ -815,9 +819,7 @@ func TestEventsInterceptor_GetStateAccessesPerAccounts(t *testing.T) {
 				SmartContractResults: scrs,
 				InvalidTxs:           invalidTxs,
 			},
-			StateAccesses: map[string]*outport.StateAccessesForBlock{
-				hex.EncodeToString(blockHash): {stateAccesses},
-			},
+			StateAccesses: stateAccesses,
 		}
 
 		args := createMockEventsInterceptorArgs()
@@ -866,14 +868,13 @@ func TestEventsInterceptor_GetStateAccessesPerAccounts(t *testing.T) {
 
 		blockEvents := &data.ArgsSaveBlockData{
 			HeaderHash: blockHash,
+			Header:     &block.HeaderV3{},
 			TransactionsPool: &outport.TransactionPool{
 				Transactions:         txs,
 				SmartContractResults: scrs,
 				InvalidTxs:           invalidTxs,
 			},
-			StateAccesses: map[string]*outport.StateAccessesForBlock{
-				hex.EncodeToString(blockHash): {stateAccesses},
-			},
+			StateAccesses: stateAccesses,
 		}
 
 		expStateAccessesPerAccounts := make(map[string]*stateChange.StateAccesses)
@@ -914,7 +915,288 @@ func TestEventsInterceptor_GetStateAccessesPerAccounts(t *testing.T) {
 				SmartContractResults: scrs,
 				InvalidTxs:           invalidTxs,
 			},
-			StateAccesses: map[string]*outport.StateAccessesForBlock{
+			StateAccesses: stateAccessesReadWrite,
+		}
+
+		expStateAccessesPerAccounts := make(map[string]*stateChange.StateAccesses)
+		expStateAccessesPerAccounts[hex.EncodeToString([]byte("mainTrieKey1"))] = &stateChange.StateAccesses{
+			StateAccess: []*stateChange.StateAccess{
+				&stateChange.StateAccess{
+					Type:        stateChange.Read,
+					MainTrieKey: []byte("mainTrieKey1"),
+					MainTrieVal: []byte("mainTrieVal1"),
+				},
+			},
+		}
+		expStateAccessesPerAccounts[hex.EncodeToString([]byte("mainTrieKey2"))] = &stateChange.StateAccesses{
+			StateAccess: []*stateChange.StateAccess{
+				&stateChange.StateAccess{
+					Type:        stateChange.Read,
+					MainTrieKey: []byte("mainTrieKey2"),
+					MainTrieVal: []byte("mainTrieVal4"),
+				},
+				&stateChange.StateAccess{
+					Type:        stateChange.Write,
+					MainTrieKey: []byte("mainTrieKey2"),
+					MainTrieVal: []byte("mainTrieVal2"),
+				},
+			},
+		}
+		expStateAccessesPerAccounts[hex.EncodeToString([]byte("mainTrieKey3"))] = &stateChange.StateAccesses{
+			StateAccess: []*stateChange.StateAccess{
+				&stateChange.StateAccess{
+					Type:        stateChange.Write,
+					MainTrieKey: []byte("mainTrieKey3"),
+					MainTrieVal: []byte("mainTrieVal3"),
+				},
+			},
+		}
+
+		args := createMockEventsInterceptorArgs()
+		args.WithReadStateChanges = true
+		en, _ := process.NewEventsInterceptor(args)
+
+		stateAccessesPerAccounts := en.GetStateAccessesPerAccounts(blockEvents)
+
+		require.Equal(t, expStateAccessesPerAccounts, stateAccessesPerAccounts)
+	})
+
+	// with header V3
+
+	t.Run("with write operations", func(t *testing.T) {
+		t.Parallel()
+
+		stateAccesses := make(map[string]*stateChange.StateAccesses)
+		stateAccesses["txHash1"] = &stateChange.StateAccesses{
+			StateAccess: []*stateChange.StateAccess{
+				{
+					Type:        stateChange.Write,
+					MainTrieKey: []byte("mainTrieKey1"),
+					MainTrieVal: []byte("mainTrieVal1"),
+				},
+				{
+					Type:        stateChange.Write,
+					MainTrieKey: []byte("mainTrieKey2"),
+					MainTrieVal: []byte("mainTrieVal2"),
+				},
+			},
+		}
+		stateAccesses["txHash2"] = &stateChange.StateAccesses{}
+		stateAccesses["txHash0"] = &stateChange.StateAccesses{
+			StateAccess: []*stateChange.StateAccess{
+				{
+					Type:        stateChange.Write,
+					MainTrieKey: []byte("mainTrieKey3"),
+					MainTrieVal: []byte("mainTrieVal3"),
+				},
+				{
+					Type:        stateChange.Write,
+					MainTrieKey: []byte("mainTrieKey2"),
+					MainTrieVal: []byte("mainTrieVal4"),
+				},
+			},
+		}
+
+		blockEvents := &data.ArgsSaveBlockData{
+			HeaderHash: blockHash,
+			TransactionsPool: &outport.TransactionPool{
+				Transactions:         txs,
+				SmartContractResults: scrs,
+				InvalidTxs:           invalidTxs,
+			},
+			StateAccesses: make(map[string]*stateChange.StateAccesses),
+			StateAccessesForBlock: map[string]*outport.StateAccessesForBlock{
+				hex.EncodeToString(blockHash): {stateAccesses},
+			},
+		}
+
+		expStateAccessesPerAccounts := make(map[string]*stateChange.StateAccesses)
+		expStateAccessesPerAccounts[hex.EncodeToString([]byte("mainTrieKey1"))] = &stateChange.StateAccesses{
+			StateAccess: []*stateChange.StateAccess{
+				{
+					Type:        stateChange.Write,
+					MainTrieKey: []byte("mainTrieKey1"),
+					MainTrieVal: []byte("mainTrieVal1"),
+				},
+			},
+		}
+		expStateAccessesPerAccounts[hex.EncodeToString([]byte("mainTrieKey2"))] = &stateChange.StateAccesses{
+			StateAccess: []*stateChange.StateAccess{
+				{
+					Type:        stateChange.Write,
+					MainTrieKey: []byte("mainTrieKey2"),
+					MainTrieVal: []byte("mainTrieVal4"),
+				},
+				{
+					Type:        stateChange.Write,
+					MainTrieKey: []byte("mainTrieKey2"),
+					MainTrieVal: []byte("mainTrieVal2"),
+				},
+			},
+		}
+		expStateAccessesPerAccounts[hex.EncodeToString([]byte("mainTrieKey3"))] = &stateChange.StateAccesses{
+			StateAccess: []*stateChange.StateAccess{
+				{
+					Type:        stateChange.Write,
+					MainTrieKey: []byte("mainTrieKey3"),
+					MainTrieVal: []byte("mainTrieVal3"),
+				},
+			},
+		}
+
+		args := createMockEventsInterceptorArgs()
+		en, _ := process.NewEventsInterceptor(args)
+
+		stateAccessesPerAccounts := en.GetStateAccessesPerAccountsV3(blockEvents)
+
+		require.Equal(t, expStateAccessesPerAccounts, stateAccessesPerAccounts)
+	})
+
+	t.Run("with read operations, but not enabled from config", func(t *testing.T) {
+		t.Parallel()
+
+		stateAccesses := make(map[string]*stateChange.StateAccesses)
+		stateAccesses["txHash1"] = &stateChange.StateAccesses{
+			StateAccess: []*stateChange.StateAccess{
+				{
+					Type:        stateChange.Read,
+					MainTrieKey: []byte("mainTrieKey1"),
+					MainTrieVal: []byte("mainTrieVal1"),
+				},
+				{
+					Type:        stateChange.Read,
+					MainTrieKey: []byte("mainTrieKey2"),
+					MainTrieVal: []byte("mainTrieVal2"),
+				},
+			},
+		}
+		stateAccesses["txHash2"] = &stateChange.StateAccesses{}
+		stateAccesses["txHash0"] = &stateChange.StateAccesses{
+			StateAccess: []*stateChange.StateAccess{
+				{
+					Type:        stateChange.Read,
+					MainTrieKey: []byte("mainTrieKey3"),
+					MainTrieVal: []byte("mainTrieVal3"),
+				},
+				{
+					Type:        stateChange.Read,
+					MainTrieKey: []byte("mainTrieKey2"),
+					MainTrieVal: []byte("mainTrieVal4"),
+				},
+			},
+		}
+
+		blockEvents := &data.ArgsSaveBlockData{
+			HeaderHash: blockHash,
+			TransactionsPool: &outport.TransactionPool{
+				Transactions:         txs,
+				SmartContractResults: scrs,
+				InvalidTxs:           invalidTxs,
+			},
+			StateAccesses: make(map[string]*stateChange.StateAccesses),
+			StateAccessesForBlock: map[string]*outport.StateAccessesForBlock{
+				hex.EncodeToString(blockHash): {stateAccesses},
+			},
+		}
+
+		args := createMockEventsInterceptorArgs()
+		en, _ := process.NewEventsInterceptor(args)
+
+		expStateAccessesPerAccounts := make(map[string]*stateChange.StateAccesses)
+
+		stateAccessesPerAccounts := en.GetStateAccessesPerAccountsV3(blockEvents)
+
+		require.Equal(t, expStateAccessesPerAccounts, stateAccessesPerAccounts)
+	})
+
+	t.Run("with read (not enabled from config) and write operations", func(t *testing.T) {
+		t.Parallel()
+
+		stateAccesses := make(map[string]*stateChange.StateAccesses)
+		stateAccesses["txHash1"] = &stateChange.StateAccesses{
+			StateAccess: []*stateChange.StateAccess{
+				{
+					Type:        stateChange.Read,
+					MainTrieKey: []byte("mainTrieKey1"),
+					MainTrieVal: []byte("mainTrieVal1"),
+				},
+				{
+					Type:        stateChange.Write,
+					MainTrieKey: []byte("mainTrieKey2"),
+					MainTrieVal: []byte("mainTrieVal2"),
+				},
+			},
+		}
+		stateAccesses["txHash2"] = &stateChange.StateAccesses{}
+		stateAccesses["txHash0"] = &stateChange.StateAccesses{
+			StateAccess: []*stateChange.StateAccess{
+				{
+					Type:        stateChange.Write,
+					MainTrieKey: []byte("mainTrieKey3"),
+					MainTrieVal: []byte("mainTrieVal3"),
+				},
+				{
+					Type:        stateChange.Read,
+					MainTrieKey: []byte("mainTrieKey2"),
+					MainTrieVal: []byte("mainTrieVal4"),
+				},
+			},
+		}
+
+		blockEvents := &data.ArgsSaveBlockData{
+			HeaderHash: blockHash,
+			Header:     &block.HeaderV3{},
+			TransactionsPool: &outport.TransactionPool{
+				Transactions:         txs,
+				SmartContractResults: scrs,
+				InvalidTxs:           invalidTxs,
+			},
+			StateAccesses: make(map[string]*stateChange.StateAccesses),
+			StateAccessesForBlock: map[string]*outport.StateAccessesForBlock{
+				hex.EncodeToString(blockHash): {stateAccesses},
+			},
+		}
+
+		expStateAccessesPerAccounts := make(map[string]*stateChange.StateAccesses)
+		expStateAccessesPerAccounts[hex.EncodeToString([]byte("mainTrieKey2"))] = &stateChange.StateAccesses{
+			StateAccess: []*stateChange.StateAccess{
+				{
+					Type:        stateChange.Write,
+					MainTrieKey: []byte("mainTrieKey2"),
+					MainTrieVal: []byte("mainTrieVal2"),
+				},
+			},
+		}
+		expStateAccessesPerAccounts[hex.EncodeToString([]byte("mainTrieKey3"))] = &stateChange.StateAccesses{
+			StateAccess: []*stateChange.StateAccess{
+				{
+					Type:        stateChange.Write,
+					MainTrieKey: []byte("mainTrieKey3"),
+					MainTrieVal: []byte("mainTrieVal3"),
+				},
+			},
+		}
+
+		args := createMockEventsInterceptorArgs()
+		en, _ := process.NewEventsInterceptor(args)
+
+		stateAccessesPerAccounts := en.GetStateAccessesPerAccountsV3(blockEvents)
+
+		require.Equal(t, expStateAccessesPerAccounts, stateAccessesPerAccounts)
+	})
+
+	t.Run("with read and write operations", func(t *testing.T) {
+		t.Parallel()
+
+		blockEvents := &data.ArgsSaveBlockData{
+			HeaderHash: blockHash,
+			TransactionsPool: &outport.TransactionPool{
+				Transactions:         txs,
+				SmartContractResults: scrs,
+				InvalidTxs:           invalidTxs,
+			},
+			StateAccesses: make(map[string]*stateChange.StateAccesses),
+			StateAccessesForBlock: map[string]*outport.StateAccessesForBlock{
 				hex.EncodeToString(blockHash): {stateAccessesReadWrite},
 			},
 		}
@@ -957,7 +1239,7 @@ func TestEventsInterceptor_GetStateAccessesPerAccounts(t *testing.T) {
 		args.WithReadStateChanges = true
 		en, _ := process.NewEventsInterceptor(args)
 
-		stateAccessesPerAccounts := en.GetStateAccessesPerAccounts(blockEvents)
+		stateAccessesPerAccounts := en.GetStateAccessesPerAccountsV3(blockEvents)
 
 		require.Equal(t, expStateAccessesPerAccounts, stateAccessesPerAccounts)
 	})

--- a/process/eventsInterceptor_test.go
+++ b/process/eventsInterceptor_test.go
@@ -567,7 +567,7 @@ func TestGetLogEventsFromTransactionsPool(t *testing.T) {
 	require.Equal(t, txHash2, receivedEvents[2].TxHash)
 }
 
-func TestEventsInterceptor_GetStateAccessesPerAccountsV3(t *testing.T) {
+func TestEventsInterceptor_GetStateAccessesPerAccounts(t *testing.T) {
 	t.Parallel()
 
 	txs := map[string]*outport.TxInfo{

--- a/process/export_test.go
+++ b/process/export_test.go
@@ -48,6 +48,11 @@ func (ei *eventsInterceptor) GetStateAccessesPerAccounts(eventsData *data.ArgsSa
 	return ei.getStateAccessesPerAccounts(eventsData, hex.EncodeToString(eventsData.HeaderHash), eventsData.TransactionsPool)
 }
 
+// GetStateAccessesPerAccountsV3 -
+func (ei *eventsInterceptor) GetStateAccessesPerAccountsV3(eventsData *data.ArgsSaveBlockData) map[string]*stateChange.StateAccesses {
+	return ei.getStateAccessesPerAccountsV3(eventsData, hex.EncodeToString(eventsData.HeaderHash), eventsData.TransactionsPool)
+}
+
 // BaseNilEventsDataCheks -
 func BaseNilEventsDataCheks(eventsData *data.ArgsSaveBlockData) error {
 	return baseNilEventsDataChecks(eventsData)

--- a/process/preprocess/eventsPreProcessorV0.go
+++ b/process/preprocess/eventsPreProcessorV0.go
@@ -58,6 +58,7 @@ func (d *eventsPreProcessorV0) SaveBlock(marshalledData []byte) error {
 		NumberOfShards:         blockData.NumberOfShards,
 		TransactionsPool:       txsPool,
 		Header:                 header,
+		StateAccesses:          blockData.StateAccesses,
 	}
 
 	err = d.facade.HandlePushEvents(*saveBlockData)

--- a/process/preprocess/eventsPreProcessorV1.go
+++ b/process/preprocess/eventsPreProcessorV1.go
@@ -72,7 +72,8 @@ func (d *eventsPreProcessorV1) SaveBlock(marshalledData []byte) error {
 		TransactionsPool:       outportBlock.TransactionPool,
 		Header:                 header,
 		HeaderTimeStampMs:      outportBlock.BlockData.GetTimestampMs(),
-		StateAccesses:          outportBlock.GetStateAccessesForBlock(),
+		StateAccesses:          outportBlock.GetStateAccesses(),
+		StateAccessesForBlock:  outportBlock.GetStateAccessesForBlock(),
 		Results:                executionResults,
 	}
 

--- a/testdata/testData.go
+++ b/testdata/testData.go
@@ -52,6 +52,27 @@ func (bd *blockData) OldSaveBlockData() *notifierData.SaveBlockData {
 
 // OutportBlockV0 -
 func (bd *blockData) OutportBlockV0() *notifierData.ArgsSaveBlock {
+	stateAccesses := make(map[string]*stateChange.StateAccesses)
+	stateAccesses["txHash1"] = &stateChange.StateAccesses{
+		StateAccess: []*stateChange.StateAccess{
+			&stateChange.StateAccess{
+				Type:           stateChange.Write,
+				MainTrieKey:    []byte("mainTrieKey1"),
+				MainTrieVal:    []byte("mainTrieVal1"),
+				TxHash:         []byte("txHash1"),
+				AccountChanges: 8,
+			},
+			&stateChange.StateAccess{
+				Type:           stateChange.Write,
+				MainTrieKey:    []byte("mainTrieKey2"),
+				MainTrieVal:    []byte("mainTrieVal2"),
+				TxHash:         []byte("txHash1"),
+				AccountChanges: 4,
+			},
+		},
+	}
+	stateAccesses["txHash2"] = &stateChange.StateAccesses{}
+
 	saveBlockData := data.OutportBlockDataOld{
 		HeaderHash: []byte("headerHash3"),
 		Body: &block.Body{
@@ -102,6 +123,7 @@ func (bd *blockData) OutportBlockV0() *notifierData.ArgsSaveBlock {
 			},
 		},
 		NumberOfShards: 2,
+		StateAccesses:  stateAccesses,
 	}
 
 	return &data.ArgsSaveBlock{

--- a/testdata/testData.go
+++ b/testdata/testData.go
@@ -11,7 +11,6 @@ import (
 	"github.com/multiversx/mx-chain-core-go/data/transaction"
 	"github.com/multiversx/mx-chain-core-go/marshal"
 	"github.com/multiversx/mx-chain-notifier-go/common"
-	"github.com/multiversx/mx-chain-notifier-go/data"
 	notifierData "github.com/multiversx/mx-chain-notifier-go/data"
 )
 
@@ -73,7 +72,7 @@ func (bd *blockData) OutportBlockV0() *notifierData.ArgsSaveBlock {
 	}
 	stateAccesses["txHash2"] = &stateChange.StateAccesses{}
 
-	saveBlockData := data.OutportBlockDataOld{
+	saveBlockData := notifierData.OutportBlockDataOld{
 		HeaderHash: []byte("headerHash3"),
 		Body: &block.Body{
 			MiniBlocks: []*block.MiniBlock{
@@ -126,7 +125,7 @@ func (bd *blockData) OutportBlockV0() *notifierData.ArgsSaveBlock {
 		StateAccesses:  stateAccesses,
 	}
 
-	return &data.ArgsSaveBlock{
+	return &notifierData.ArgsSaveBlock{
 		HeaderType:          "Header",
 		OutportBlockDataOld: saveBlockData,
 	}


### PR DESCRIPTION
Add backwards compatibility support for state changes. 

Outport driver will expose state changes in 2 ways:
- pre-Supernova: `StateAccesses` - per block directly, with state accesses per transactions
- after-Supernova: `StateAccessesForBlock` - with multiple sets of state accesses

Added implementation to support full backwards compatibility before supernova is activated.