### PR TITLE
remove duplicated txs

### DIFF
--- a/process/eventsInterceptor.go
+++ b/process/eventsInterceptor.go
@@ -180,7 +180,11 @@ func getTxsWithOrder(transactionsPool *outport.TransactionPool) []txWithOrder {
 	// There can be a case when a transaction is included in the block, but also marked as invalid, so it will be present
 	// in both transactions and invalidTxs maps from transactions pool, with the same execution order. In that case,
 	// we want to make sure that we process that transaction only as invalid.
-	txsWithOrderMap := make(map[string]txWithOrder)
+	numTxs := len(transactionsPool.Transactions) +
+		len(transactionsPool.SmartContractResults) +
+		len(transactionsPool.Rewards) +
+		len(transactionsPool.InvalidTxs)
+	txsWithOrderMap := make(map[string]txWithOrder, numTxs)
 
 	for txHash, txInfo := range transactionsPool.Transactions {
 		txsWithOrderMap[txHash] = txWithOrder{

--- a/process/eventsInterceptor.go
+++ b/process/eventsInterceptor.go
@@ -176,36 +176,44 @@ func getTxsFromPool(transactionsPool *outport.TransactionPool) map[string]*trans
 }
 
 func getTxsWithOrder(transactionsPool *outport.TransactionPool) []txWithOrder {
-	numTxs := len(transactionsPool.Transactions) + len(transactionsPool.SmartContractResults) + len(transactionsPool.Rewards) + len(transactionsPool.InvalidTxs)
-	txsWithOrder := make([]txWithOrder, 0, numTxs)
+	// This map is needed because of duplicated transactions.
+	// There can be a case when a transaction is included in the block, but also marked as invalid, so it will be present
+	// in both transactions and invalidTxs maps from transactions pool, with the same execution order. In that case,
+	// we want to make sure that we process that transaction only as invalid.
+	txsWithOrderMap := make(map[string]txWithOrder)
 
 	for txHash, txInfo := range transactionsPool.Transactions {
-		txsWithOrder = append(txsWithOrder, txWithOrder{
+		txsWithOrderMap[txHash] = txWithOrder{
 			hash:   txHash,
 			index:  txInfo.ExecutionOrder,
 			txType: normalTx,
-		})
+		}
 	}
 	for txHash, txInfo := range transactionsPool.SmartContractResults {
-		txsWithOrder = append(txsWithOrder, txWithOrder{
+		txsWithOrderMap[txHash] = txWithOrder{
 			hash:   txHash,
 			index:  txInfo.ExecutionOrder,
 			txType: scr,
-		})
+		}
 	}
 	for txHash, txInfo := range transactionsPool.Rewards {
-		txsWithOrder = append(txsWithOrder, txWithOrder{
+		txsWithOrderMap[txHash] = txWithOrder{
 			hash:   txHash,
 			index:  txInfo.ExecutionOrder,
 			txType: rewardTx,
-		})
+		}
 	}
 	for txHash, txInfo := range transactionsPool.InvalidTxs {
-		txsWithOrder = append(txsWithOrder, txWithOrder{
+		txsWithOrderMap[txHash] = txWithOrder{
 			hash:   txHash,
 			index:  txInfo.ExecutionOrder,
 			txType: invalidTx,
-		})
+		}
+	}
+
+	txsWithOrder := make([]txWithOrder, 0, len(txsWithOrderMap))
+	for _, txWithData := range txsWithOrderMap {
+		txsWithOrder = append(txsWithOrder, txWithData)
 	}
 
 	sort.Slice(txsWithOrder, func(i, j int) bool {

--- a/process/eventsInterceptor.go
+++ b/process/eventsInterceptor.go
@@ -26,9 +26,9 @@ const (
 )
 
 type txWithOrder struct {
-	hash   string
-	index  uint32
-	txType txType
+	Hash   string
+	Index  uint32
+	TxType txType
 }
 
 // logEvent defines a log event associated with corresponding tx hash
@@ -188,30 +188,30 @@ func getTxsWithOrder(transactionsPool *outport.TransactionPool) []txWithOrder {
 
 	for txHash, txInfo := range transactionsPool.Transactions {
 		txsWithOrderMap[txHash] = txWithOrder{
-			hash:   txHash,
-			index:  txInfo.ExecutionOrder,
-			txType: normalTx,
+			Hash:   txHash,
+			Index:  txInfo.ExecutionOrder,
+			TxType: normalTx,
 		}
 	}
 	for txHash, txInfo := range transactionsPool.SmartContractResults {
 		txsWithOrderMap[txHash] = txWithOrder{
-			hash:   txHash,
-			index:  txInfo.ExecutionOrder,
-			txType: scr,
+			Hash:   txHash,
+			Index:  txInfo.ExecutionOrder,
+			TxType: scr,
 		}
 	}
 	for txHash, txInfo := range transactionsPool.Rewards {
 		txsWithOrderMap[txHash] = txWithOrder{
-			hash:   txHash,
-			index:  txInfo.ExecutionOrder,
-			txType: rewardTx,
+			Hash:   txHash,
+			Index:  txInfo.ExecutionOrder,
+			TxType: rewardTx,
 		}
 	}
 	for txHash, txInfo := range transactionsPool.InvalidTxs {
 		txsWithOrderMap[txHash] = txWithOrder{
-			hash:   txHash,
-			index:  txInfo.ExecutionOrder,
-			txType: invalidTx,
+			Hash:   txHash,
+			Index:  txInfo.ExecutionOrder,
+			TxType: invalidTx,
 		}
 	}
 
@@ -221,7 +221,7 @@ func getTxsWithOrder(transactionsPool *outport.TransactionPool) []txWithOrder {
 	}
 
 	sort.Slice(txsWithOrder, func(i, j int) bool {
-		return txsWithOrder[i].index < txsWithOrder[j].index
+		return txsWithOrder[i].Index < txsWithOrder[j].Index
 	})
 
 	return txsWithOrder
@@ -290,21 +290,21 @@ func (ei *eventsInterceptor) fetchStateAccessesPerAccounts(
 	txsWithOrder := getTxsWithOrder(transactionPool)
 
 	for _, txInfo := range txsWithOrder {
-		txHash, err := hex.DecodeString(txInfo.hash)
+		txHash, err := hex.DecodeString(txInfo.Hash)
 		if err != nil {
-			log.Error("failed to decode tx hash", "txHash", txInfo.hash)
+			log.Error("failed to decode tx hash", "txHash", txInfo.Hash)
 			continue
 		}
 
 		stateAccessesPerTx, ok := stateAccesses[string(txHash)]
 		if !ok {
-			if txInfo.txType == scr {
+			if txInfo.TxType == scr {
 				// there are cases when SCRs are generated but no state accesses are produced, so we will not log a warning in those cases
-				log.Trace("SCR with no state accesses", "txHash", txInfo.hash)
+				log.Trace("SCR with no state accesses", "txHash", txInfo.Hash)
 				continue
 			}
 
-			log.Warn("did not find state accesses for tx", "txHash", txInfo.hash, "txType", txInfo.txType)
+			log.Warn("did not find state accesses for tx", "txHash", txInfo.Hash, "txType", txInfo.TxType)
 			continue
 		}
 

--- a/process/eventsInterceptor_test.go
+++ b/process/eventsInterceptor_test.go
@@ -13,7 +13,6 @@ import (
 	"github.com/multiversx/mx-chain-notifier-go/data"
 	"github.com/multiversx/mx-chain-notifier-go/mocks"
 	"github.com/multiversx/mx-chain-notifier-go/process"
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
@@ -1276,5 +1275,27 @@ func TestEventsInterceptor_GetTxsWithOrder(t *testing.T) {
 	}
 
 	txsWithOrder := process.GetTxsWithOrder(transactionPool)
-	assert.Len(t, txsWithOrder, 4)
+
+	// we expect one entry for each execution order 0..3,
+	// with the duplicate "hash1" treated as invalid
+	require.Len(t, txsWithOrder, 4)
+	var hashes []string
+	invalidCount := 0
+	for _, tx := range txsWithOrder {
+		hashes = append(hashes, tx.Hash)
+		if tx.TxType == 3 { //invalid tx
+			invalidCount++
+		}
+	}
+	// execution order should be preserved: 0,1,2,3 -> hash1,hash2,hash3,hash4
+	require.Equal(t, []string{"hash1", "hash2", "hash3", "hash4"}, hashes)
+	// "hash1" should appear exactly once and be marked invalid
+	hash1Count := 0
+	for _, h := range hashes {
+		if h == "hash1" {
+			hash1Count++
+		}
+	}
+	require.Equal(t, 1, hash1Count)
+	require.Equal(t, invalidCount, 1)
 }

--- a/process/eventsInterceptor_test.go
+++ b/process/eventsInterceptor_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/multiversx/mx-chain-notifier-go/data"
 	"github.com/multiversx/mx-chain-notifier-go/mocks"
 	"github.com/multiversx/mx-chain-notifier-go/process"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
@@ -1243,4 +1244,37 @@ func TestEventsInterceptor_GetStateAccessesPerAccounts(t *testing.T) {
 
 		require.Equal(t, expStateAccessesPerAccounts, stateAccessesPerAccounts)
 	})
+}
+
+func TestEventsInterceptor_GetTxsWithOrder(t *testing.T) {
+	t.Parallel()
+
+	transactionPool := &outport.TransactionPool{
+		Transactions: map[string]*outport.TxInfo{
+			"hash1": {
+				ExecutionOrder: 0,
+			},
+			"hash2": {
+				ExecutionOrder: 1,
+			},
+		},
+		SmartContractResults: map[string]*outport.SCRInfo{
+			"hash3": {
+				ExecutionOrder: 2,
+			},
+		},
+		Rewards: map[string]*outport.RewardInfo{
+			"hash4": {
+				ExecutionOrder: 3,
+			},
+		},
+		InvalidTxs: map[string]*outport.TxInfo{
+			"hash1": {
+				ExecutionOrder: 0,
+			},
+		},
+	}
+
+	txsWithOrder := process.GetTxsWithOrder(transactionPool)
+	assert.Len(t, txsWithOrder, 4)
 }

--- a/process/export_test.go
+++ b/process/export_test.go
@@ -3,6 +3,7 @@ package process
 import (
 	"encoding/hex"
 
+	"github.com/multiversx/mx-chain-core-go/data/outport"
 	"github.com/multiversx/mx-chain-core-go/data/stateChange"
 	"github.com/multiversx/mx-chain-core-go/data/transaction"
 	"github.com/multiversx/mx-chain-notifier-go/data"
@@ -56,4 +57,9 @@ func (ei *eventsInterceptor) GetStateAccessesPerAccountsV3(eventsData *data.Args
 // BaseNilEventsDataCheks -
 func BaseNilEventsDataCheks(eventsData *data.ArgsSaveBlockData) error {
 	return baseNilEventsDataChecks(eventsData)
+}
+
+// GetTxsWithOrder exports internal method for testing
+func GetTxsWithOrder(transactionsPool *outport.TransactionPool) []txWithOrder {
+	return getTxsWithOrder(transactionsPool)
 }

--- a/process/export_test.go
+++ b/process/export_test.go
@@ -59,7 +59,22 @@ func BaseNilEventsDataCheks(eventsData *data.ArgsSaveBlockData) error {
 	return baseNilEventsDataChecks(eventsData)
 }
 
+type txsWithOrderExportedFields struct {
+	Hash   string
+	Index  uint32
+	TxType txType
+}
+
 // GetTxsWithOrder exports internal method for testing
-func GetTxsWithOrder(transactionsPool *outport.TransactionPool) []txWithOrder {
-	return getTxsWithOrder(transactionsPool)
+func GetTxsWithOrder(transactionsPool *outport.TransactionPool) []txsWithOrderExportedFields {
+	txsWithOrder := getTxsWithOrder(transactionsPool)
+	txsWithExportedFields := make([]txsWithOrderExportedFields, len(txsWithOrder))
+	for i, tx := range txsWithOrder {
+		txsWithExportedFields[i] = txsWithOrderExportedFields{
+			Hash:   tx.hash,
+			Index:  tx.index,
+			TxType: tx.txType,
+		}
+	}
+	return txsWithExportedFields
 }

--- a/process/export_test.go
+++ b/process/export_test.go
@@ -59,22 +59,7 @@ func BaseNilEventsDataCheks(eventsData *data.ArgsSaveBlockData) error {
 	return baseNilEventsDataChecks(eventsData)
 }
 
-type txsWithOrderExportedFields struct {
-	Hash   string
-	Index  uint32
-	TxType txType
-}
-
 // GetTxsWithOrder exports internal method for testing
-func GetTxsWithOrder(transactionsPool *outport.TransactionPool) []txsWithOrderExportedFields {
-	txsWithOrder := getTxsWithOrder(transactionsPool)
-	txsWithExportedFields := make([]txsWithOrderExportedFields, len(txsWithOrder))
-	for i, tx := range txsWithOrder {
-		txsWithExportedFields[i] = txsWithOrderExportedFields{
-			Hash:   tx.hash,
-			Index:  tx.index,
-			TxType: tx.txType,
-		}
-	}
-	return txsWithExportedFields
+func GetTxsWithOrder(transactionsPool *outport.TransactionPool) []txWithOrder {
+	return getTxsWithOrder(transactionsPool)
 }


### PR DESCRIPTION
This pull request refactors the logic for collecting transactions from the pool to handle duplicate transactions more robustly. The main improvement is ensuring that transactions present in both the valid and invalid pools are only processed as invalid, preventing duplicate processing. The code now uses a map to deduplicate transactions before assembling the ordered list.

Handling of duplicate transactions:

* Changed the `getTxsWithOrder` function to use a map (`txsWithOrderMap`) instead of a slice to collect transactions, ensuring each transaction hash appears only once and is processed as invalid if present in both pools.
* Assembles the final ordered slice from the map, maintaining correct execution order and transaction type.