### PR TITLE
Rabbitmq client reconnect improvements

### DIFF
--- a/integrationTests/rabbitmq/testNotifierWithRabbitMQ_test.go
+++ b/integrationTests/rabbitmq/testNotifierWithRabbitMQ_test.go
@@ -59,7 +59,7 @@ func testNotifierWithRabbitMQ(t *testing.T, observerType string, payloadVersion 
 	go pushEventsRequest(wg, client)
 	go pushRevertRequest(wg, client)
 
-	integrationTests.WaitTimeout(t, wg, time.Second*2)
+	integrationTests.WaitTimeout(t, wg, time.Second*5)
 
 	assert.Equal(t, 3, len(notifier.RedisClient.GetEntries()))
 	assert.Equal(t, 7, len(notifier.RabbitMQClient.GetEntries()))

--- a/rabbitmq/errors.go
+++ b/rabbitmq/errors.go
@@ -10,3 +10,6 @@ var ErrInvalidRabbitMqExchangeName = errors.New("invalid rabbitmq exchange name"
 
 // ErrInvalidRabbitMqExchangeType signals that an empty rabbitmq exchange type has been provided
 var ErrInvalidRabbitMqExchangeType = errors.New("invalid rabbitmq exchange type")
+
+// ErrClientClosed signals that the rabbitmq client has been closed
+var ErrClientClosed = errors.New("rabbitmq client is closed")

--- a/rabbitmq/export_test.go
+++ b/rabbitmq/export_test.go
@@ -1,0 +1,1 @@
+package rabbitmq

--- a/rabbitmq/export_test.go
+++ b/rabbitmq/export_test.go
@@ -1,1 +1,0 @@
-package rabbitmq

--- a/rabbitmq/rabbitClient.go
+++ b/rabbitmq/rabbitClient.go
@@ -145,12 +145,11 @@ func (rc *rabbitMqClient) Publish(exchange, key string, mandatory, immediate boo
 			return ErrClientClosed
 		}
 
-		state := rc.currentState()
-		if state.ch == nil {
+		if rc.ch == nil {
 			return ErrClientClosed
 		}
 
-		err := state.ch.Publish(
+		err := rc.ch.Publish(
 			exchange,
 			key,
 			mandatory,
@@ -167,7 +166,7 @@ func (rc *rabbitMqClient) Publish(exchange, key string, mandatory, immediate boo
 		}
 
 		select {
-		case deliveryTag, ok := <-state.ackCh:
+		case deliveryTag, ok := <-rc.ackCh:
 			if !ok {
 				// the confirmations channel is closed together with the amqp channel,
 				// so this is a failed publish, not an acknowledgement
@@ -178,7 +177,7 @@ func (rc *rabbitMqClient) Publish(exchange, key string, mandatory, immediate boo
 
 			log.Debug("Publish: published message ack", "deliveryTag", deliveryTag)
 			return nil
-		case deliveryTag, ok := <-state.nackCh:
+		case deliveryTag, ok := <-rc.nackCh:
 			if !ok {
 				log.Debug("Publish: confirmations channel closed, will retry to publish message", "exchange", exchange)
 				rc.recoverConnection()
@@ -186,26 +185,17 @@ func (rc *rabbitMqClient) Publish(exchange, key string, mandatory, immediate boo
 			}
 
 			log.Debug("Publish: published message nack, will retry to publish message", "deliveryTag", deliveryTag)
-		case amqpErr := <-state.connErrCh:
-			logAmqpFailure("rabbitMQ connection failure", amqpErr)
+		case amqpErr := <-rc.connErrCh:
+			log.Error("rabbitMQ connection failure", "err", amqpErr.Error())
 			rc.Reconnect()
-		case amqpErr := <-state.chanErr:
-			logAmqpFailure("rabbitMQ channel failure", amqpErr)
+		case amqpErr := <-rc.chanErr:
+			log.Error("rabbitMQ channel failure", "err", amqpErr.Error())
 
 			// a connection failure is broadcast on the channel notification as well, so
 			// the recovery has to check what was actually lost
 			rc.recoverConnection()
 		}
 	}
-}
-
-func logAmqpFailure(message string, amqpErr *amqp.Error) {
-	if amqpErr == nil {
-		log.Error(message, "err", "notification channel closed")
-		return
-	}
-
-	log.Error(message, "err", amqpErr.Error())
 }
 
 // ConnErrChan will return connection error channel
@@ -222,19 +212,6 @@ func (rc *rabbitMqClient) CloseErrChan() chan *amqp.Error {
 	defer rc.connMut.RUnlock()
 
 	return rc.chanErr
-}
-
-func (rc *rabbitMqClient) currentState() connState {
-	rc.connMut.RLock()
-	defer rc.connMut.RUnlock()
-
-	return connState{
-		ch:        rc.ch,
-		connErrCh: rc.connErrCh,
-		chanErr:   rc.chanErr,
-		ackCh:     rc.ackCh,
-		nackCh:    rc.nackCh,
-	}
 }
 
 // connect will create a new connection and a new channel, closing the previous ones if

--- a/rabbitmq/rabbitClient.go
+++ b/rabbitmq/rabbitClient.go
@@ -10,6 +10,12 @@ import (
 const (
 	reconnectRetryMs = 500
 
+	// notifyChanBufferSize is the buffer size used for the amqp notification channels.
+	// It has to be at least 1: on connection/channel shutdown the amqp library sends the
+	// close notification while holding its internal mutex, so an unbuffered channel with
+	// no reader (no publish in progress) would block the whole shutdown.
+	notifyChanBufferSize = 1
+
 	// ExchangeDeclare constants
 	isDurable  = true
 	autoDelete = false
@@ -17,27 +23,55 @@ const (
 	noWait     = false
 )
 
-type rabbitMqClient struct {
-	url    string
-	pubMut sync.Mutex
+// exchangeDeclaration holds the data needed to (re)declare an exchange
+type exchangeDeclaration struct {
+	name string
+	kind string
+}
 
-	conn *amqp.Connection
-	ch   *amqp.Channel
-
+// connState holds a consistent snapshot of the currently used connection resources
+type connState struct {
+	ch        *amqp.Channel
 	connErrCh chan *amqp.Error
 	chanErr   chan *amqp.Error
 	ackCh     chan uint64
 	nackCh    chan uint64
 }
 
+type rabbitMqClient struct {
+	url    string
+	pubMut sync.Mutex
+
+	// dialFunc and retryInterval are set on creation, they are overridden only in tests
+	dialFunc      func(url string) (*amqp.Connection, error)
+	retryInterval time.Duration
+
+	connMut sync.RWMutex
+	conn    *amqp.Connection
+	ch      *amqp.Channel
+
+	connErrCh chan *amqp.Error
+	chanErr   chan *amqp.Error
+	ackCh     chan uint64
+	nackCh    chan uint64
+
+	exchanges []exchangeDeclaration
+
+	closeChan chan struct{}
+	closeOnce sync.Once
+}
+
 // NewRabbitMQClient creates a new rabbitMQ client instance
 func NewRabbitMQClient(url string) (*rabbitMqClient, error) {
 	rc := &rabbitMqClient{
-		url:    url,
-		pubMut: sync.Mutex{},
+		url:           url,
+		pubMut:        sync.Mutex{},
+		dialFunc:      amqp.Dial,
+		retryInterval: time.Millisecond * reconnectRetryMs,
+		closeChan:     make(chan struct{}),
 	}
 
-	err := rc.connect()
+	err := rc.tryConnect()
 	if err != nil {
 		return nil, err
 	}
@@ -45,9 +79,31 @@ func NewRabbitMQClient(url string) (*rabbitMqClient, error) {
 	return rc, nil
 }
 
-// ExchangeDeclare will declare an exchange
+// ExchangeDeclare will declare an exchange. The declaration is saved, so that it can be
+// applied again on every newly opened channel. This is needed because a reconnect may
+// end up on a different rabbitmq instance (for example if the server IP behind the
+// configured host has changed), which does not have the exchanges declared yet.
 func (rc *rabbitMqClient) ExchangeDeclare(name, kind string) error {
-	return rc.ch.ExchangeDeclare(
+	rc.connMut.RLock()
+	ch := rc.ch
+	rc.connMut.RUnlock()
+
+	if ch == nil {
+		return ErrClientClosed
+	}
+
+	err := declareExchange(ch, name, kind)
+	if err != nil {
+		return err
+	}
+
+	rc.saveExchangeDeclaration(name, kind)
+
+	return nil
+}
+
+func declareExchange(ch *amqp.Channel, name, kind string) error {
+	return ch.ExchangeDeclare(
 		name,
 		kind,
 		isDurable,
@@ -56,6 +112,20 @@ func (rc *rabbitMqClient) ExchangeDeclare(name, kind string) error {
 		noWait,
 		nil,
 	)
+}
+
+func (rc *rabbitMqClient) saveExchangeDeclaration(name, kind string) {
+	rc.connMut.Lock()
+	defer rc.connMut.Unlock()
+
+	for idx, exchange := range rc.exchanges {
+		if exchange.name == name {
+			rc.exchanges[idx].kind = kind
+			return
+		}
+	}
+
+	rc.exchanges = append(rc.exchanges, exchangeDeclaration{name: name, kind: kind})
 }
 
 // Publish will publich an item on the rabbitMq channel
@@ -71,7 +141,16 @@ func (rc *rabbitMqClient) Publish(exchange, key string, mandatory, immediate boo
 	// main loop will not catch the conn err event, and it will still try to
 	// publish the message.
 	for {
-		err := rc.ch.Publish(
+		if rc.isClosed() {
+			return ErrClientClosed
+		}
+
+		state := rc.currentState()
+		if state.ch == nil {
+			return ErrClientClosed
+		}
+
+		err := state.ch.Publish(
 			exchange,
 			key,
 			mandatory,
@@ -79,115 +158,293 @@ func (rc *rabbitMqClient) Publish(exchange, key string, mandatory, immediate boo
 			msg,
 		)
 		if err != nil {
+			// no confirmation will ever be received for a failed publish, so the
+			// connection/channel has to be restored before trying again, otherwise
+			// this would spin without ever making progress
 			log.Error("failed to publish message", "exchange", exchange, "error", err.Error())
+			rc.recoverConnection()
+			continue
 		}
 
 		select {
-		case deliveryTag := <-rc.ackCh:
+		case deliveryTag, ok := <-state.ackCh:
+			if !ok {
+				// the confirmations channel is closed together with the amqp channel,
+				// so this is a failed publish, not an acknowledgement
+				log.Debug("Publish: confirmations channel closed, will retry to publish message", "exchange", exchange)
+				rc.recoverConnection()
+				continue
+			}
+
 			log.Debug("Publish: published message ack", "deliveryTag", deliveryTag)
-			return err
-		case deliveryTag := <-rc.nackCh:
+			return nil
+		case deliveryTag, ok := <-state.nackCh:
+			if !ok {
+				log.Debug("Publish: confirmations channel closed, will retry to publish message", "exchange", exchange)
+				rc.recoverConnection()
+				continue
+			}
+
 			log.Debug("Publish: published message nack, will retry to publish message", "deliveryTag", deliveryTag)
-		case err := <-rc.connErrCh:
-			if err != nil {
-				log.Error("rabbitMQ connection failure", "err", err.Error())
-				rc.Reconnect()
-			}
-		case err := <-rc.chanErr:
-			if err != nil {
-				log.Error("rabbitMQ channel failure", "err", err.Error())
-				rc.ReopenChannel()
-			}
+		case amqpErr := <-state.connErrCh:
+			logAmqpFailure("rabbitMQ connection failure", amqpErr)
+			rc.Reconnect()
+		case amqpErr := <-state.chanErr:
+			logAmqpFailure("rabbitMQ channel failure", amqpErr)
+
+			// a connection failure is broadcast on the channel notification as well, so
+			// the recovery has to check what was actually lost
+			rc.recoverConnection()
 		}
 	}
 }
 
-// dial will return a rabbitMq connection
-func (rc *rabbitMqClient) dial(url string) (*amqp.Connection, error) {
-	return amqp.Dial(url)
+func logAmqpFailure(message string, amqpErr *amqp.Error) {
+	if amqpErr == nil {
+		log.Error(message, "err", "notification channel closed")
+		return
+	}
+
+	log.Error(message, "err", amqpErr.Error())
 }
 
 // ConnErrChan will return connection error channel
 func (rc *rabbitMqClient) ConnErrChan() chan *amqp.Error {
+	rc.connMut.RLock()
+	defer rc.connMut.RUnlock()
+
 	return rc.connErrCh
 }
 
 // CloseErrChan will return closing error channel
 func (rc *rabbitMqClient) CloseErrChan() chan *amqp.Error {
+	rc.connMut.RLock()
+	defer rc.connMut.RUnlock()
+
 	return rc.chanErr
 }
 
-func (rc *rabbitMqClient) connect() error {
-	conn, err := rc.dial(rc.url)
-	if err != nil {
-		return err
+func (rc *rabbitMqClient) currentState() connState {
+	rc.connMut.RLock()
+	defer rc.connMut.RUnlock()
+
+	return connState{
+		ch:        rc.ch,
+		connErrCh: rc.connErrCh,
+		chanErr:   rc.chanErr,
+		ackCh:     rc.ackCh,
+		nackCh:    rc.nackCh,
 	}
-	rc.conn = conn
-
-	rc.connErrCh = make(chan *amqp.Error)
-	rc.conn.NotifyClose(rc.connErrCh)
-
-	err = rc.openChannel()
-	if err != nil {
-		return err
-	}
-
-	return nil
 }
 
+// connect will create a new connection and a new channel, closing the previous ones if
+// still around. It has to be called while holding the connMut write lock.
+func (rc *rabbitMqClient) connect() error {
+	rc.closeConnectionAndChannel()
+
+	conn, err := rc.dialFunc(rc.url)
+	if err != nil {
+		return err
+	}
+
+	if rc.isClosed() {
+		// the client was closed while dialing, do not leak the new connection
+		closeConnection(conn)
+		return ErrClientClosed
+	}
+
+	rc.conn = conn
+
+	rc.connErrCh = make(chan *amqp.Error, notifyChanBufferSize)
+	rc.conn.NotifyClose(rc.connErrCh)
+
+	return rc.openChannel()
+}
+
+// openChannel will open a new channel on the existing connection, closing the previous
+// one if still around. It has to be called while holding the connMut write lock.
 func (rc *rabbitMqClient) openChannel() error {
+	rc.closeChannel()
+
+	if rc.conn == nil {
+		return ErrClientClosed
+	}
+
 	ch, err := rc.conn.Channel()
 	if err != nil {
 		return err
 	}
 	rc.ch = ch
 
-	rc.chanErr = make(chan *amqp.Error)
+	rc.chanErr = make(chan *amqp.Error, notifyChanBufferSize)
 	rc.ch.NotifyClose(rc.chanErr)
-	rc.ackCh, rc.nackCh = rc.ch.NotifyConfirm(make(chan uint64), make(chan uint64))
+	rc.ackCh, rc.nackCh = rc.ch.NotifyConfirm(
+		make(chan uint64, notifyChanBufferSize),
+		make(chan uint64, notifyChanBufferSize),
+	)
 
-	return rc.ch.Confirm(false)
+	err = rc.ch.Confirm(false)
+	if err != nil {
+		return err
+	}
+
+	return rc.redeclareExchanges()
+}
+
+// redeclareExchanges has to be called while holding the connMut write lock
+func (rc *rabbitMqClient) redeclareExchanges() error {
+	for _, exchange := range rc.exchanges {
+		err := declareExchange(rc.ch, exchange.name, exchange.kind)
+		if err != nil {
+			return err
+		}
+
+		log.Debug("re-declared rabbitMQ exchange", "name", exchange.name, "type", exchange.kind)
+	}
+
+	return nil
+}
+
+func (rc *rabbitMqClient) tryConnect() error {
+	rc.connMut.Lock()
+	defer rc.connMut.Unlock()
+
+	return rc.connect()
+}
+
+func (rc *rabbitMqClient) tryOpenChannel() error {
+	rc.connMut.Lock()
+	defer rc.connMut.Unlock()
+
+	return rc.openChannel()
+}
+
+// recover will restore whatever was lost: if the connection is down, re-opening only the
+// channel would never succeed, since a channel cannot be opened on a closed connection
+func (rc *rabbitMqClient) recoverConnection() {
+	if rc.connectionIsDown() {
+		rc.Reconnect()
+		return
+	}
+
+	rc.ReopenChannel()
+}
+
+func (rc *rabbitMqClient) connectionIsDown() bool {
+	rc.connMut.RLock()
+	defer rc.connMut.RUnlock()
+
+	return rc.conn == nil || rc.conn.IsClosed()
 }
 
 // Reconnect will try to reconnect to rabbitmq
 func (rc *rabbitMqClient) Reconnect() {
 	for {
-		time.Sleep(time.Millisecond * reconnectRetryMs)
+		if rc.waitBeforeRetry() {
+			log.Debug("client closed, stopping reconnect attempts")
+			return
+		}
 
-		err := rc.connect()
+		err := rc.tryConnect()
 		if err != nil {
 			log.Debug("could not reconnect", "err", err.Error())
-		} else {
-			log.Debug("connection established after reconnect attempts")
-			break
+			continue
 		}
+
+		log.Info("connection established after reconnect attempts")
+		return
 	}
 }
 
 // ReopenChannel will try to reopen communication channel
 func (rc *rabbitMqClient) ReopenChannel() {
 	for {
-		time.Sleep(time.Millisecond * reconnectRetryMs)
+		if rc.waitBeforeRetry() {
+			log.Debug("client closed, stopping channel reopen attempts")
+			return
+		}
 
-		err := rc.openChannel()
+		if rc.connectionIsDown() {
+			log.Debug("connection is down, will reconnect before re-opening the channel")
+			rc.Reconnect()
+			return
+		}
+
+		err := rc.tryOpenChannel()
 		if err != nil {
 			log.Debug("could not re-open channel", "err", err.Error())
-		} else {
-			log.Debug("channel opened after reconnect attempts")
-			break
+			continue
 		}
+
+		log.Info("channel opened after reconnect attempts")
+		return
+	}
+}
+
+// waitBeforeRetry will wait for the retry interval to pass, returning true if the client
+// has been closed in the meantime, case in which the retry loop has to be stopped
+func (rc *rabbitMqClient) waitBeforeRetry() bool {
+	timer := time.NewTimer(rc.retryInterval)
+	defer timer.Stop()
+
+	select {
+	case <-rc.closeChan:
+		return true
+	case <-timer.C:
+		return false
+	}
+}
+
+func (rc *rabbitMqClient) isClosed() bool {
+	select {
+	case <-rc.closeChan:
+		return true
+	default:
+		return false
 	}
 }
 
 // Close will close rabbitMq client connection
 func (rc *rabbitMqClient) Close() {
-	err := rc.ch.Close()
-	if err != nil {
-		log.Error("failed to close rabbitMQ channel", "err", err.Error())
+	rc.closeOnce.Do(func() {
+		close(rc.closeChan)
+	})
+
+	rc.connMut.Lock()
+	defer rc.connMut.Unlock()
+
+	rc.closeConnectionAndChannel()
+}
+
+// closeConnectionAndChannel has to be called while holding the connMut write lock
+func (rc *rabbitMqClient) closeConnectionAndChannel() {
+	rc.closeChannel()
+
+	if rc.conn == nil {
+		return
 	}
-	err = rc.conn.Close()
-	if err != nil {
-		log.Error("failed to close rabbitMQ channel", "err", err.Error())
+
+	closeConnection(rc.conn)
+	rc.conn = nil
+}
+
+// closeChannel has to be called while holding the connMut write lock
+func (rc *rabbitMqClient) closeChannel() {
+	if rc.ch == nil {
+		return
+	}
+
+	err := rc.ch.Close()
+	if err != nil && err != amqp.ErrClosed {
+		log.Debug("failed to close rabbitMQ channel", "err", err.Error())
+	}
+	rc.ch = nil
+}
+
+func closeConnection(conn *amqp.Connection) {
+	err := conn.Close()
+	if err != nil && err != amqp.ErrClosed {
+		log.Debug("failed to close rabbitMQ connection", "err", err.Error())
 	}
 }
 

--- a/rabbitmq/rabbitClient.go
+++ b/rabbitmq/rabbitClient.go
@@ -128,6 +128,19 @@ func (rc *rabbitMqClient) saveExchangeDeclaration(name, kind string) {
 	rc.exchanges = append(rc.exchanges, exchangeDeclaration{name: name, kind: kind})
 }
 
+func (rc *rabbitMqClient) currentState() connState {
+	rc.connMut.RLock()
+	defer rc.connMut.RUnlock()
+
+	return connState{
+		ch:        rc.ch,
+		connErrCh: rc.connErrCh,
+		chanErr:   rc.chanErr,
+		ackCh:     rc.ackCh,
+		nackCh:    rc.nackCh,
+	}
+}
+
 // Publish will publich an item on the rabbitMq channel
 func (rc *rabbitMqClient) Publish(exchange, key string, mandatory, immediate bool, msg amqp.Publishing) error {
 	rc.pubMut.Lock()
@@ -145,11 +158,12 @@ func (rc *rabbitMqClient) Publish(exchange, key string, mandatory, immediate boo
 			return ErrClientClosed
 		}
 
-		if rc.ch == nil {
+		state := rc.currentState()
+		if state.ch == nil {
 			return ErrClientClosed
 		}
 
-		err := rc.ch.Publish(
+		err := state.ch.Publish(
 			exchange,
 			key,
 			mandatory,
@@ -166,7 +180,7 @@ func (rc *rabbitMqClient) Publish(exchange, key string, mandatory, immediate boo
 		}
 
 		select {
-		case deliveryTag, ok := <-rc.ackCh:
+		case deliveryTag, ok := <-state.ackCh:
 			if !ok {
 				// the confirmations channel is closed together with the amqp channel,
 				// so this is a failed publish, not an acknowledgement
@@ -177,7 +191,7 @@ func (rc *rabbitMqClient) Publish(exchange, key string, mandatory, immediate boo
 
 			log.Debug("Publish: published message ack", "deliveryTag", deliveryTag)
 			return nil
-		case deliveryTag, ok := <-rc.nackCh:
+		case deliveryTag, ok := <-state.nackCh:
 			if !ok {
 				log.Debug("Publish: confirmations channel closed, will retry to publish message", "exchange", exchange)
 				rc.recoverConnection()
@@ -185,10 +199,10 @@ func (rc *rabbitMqClient) Publish(exchange, key string, mandatory, immediate boo
 			}
 
 			log.Debug("Publish: published message nack, will retry to publish message", "deliveryTag", deliveryTag)
-		case amqpErr := <-rc.connErrCh:
+		case amqpErr := <-state.connErrCh:
 			log.Error("rabbitMQ connection failure", "err", amqpErr.Error())
 			rc.Reconnect()
-		case amqpErr := <-rc.chanErr:
+		case amqpErr := <-state.chanErr:
 			log.Error("rabbitMQ channel failure", "err", amqpErr.Error())
 
 			// a connection failure is broadcast on the channel notification as well, so

--- a/rabbitmq/rabbitClient.go
+++ b/rabbitmq/rabbitClient.go
@@ -199,17 +199,26 @@ func (rc *rabbitMqClient) Publish(exchange, key string, mandatory, immediate boo
 			}
 
 			log.Debug("Publish: published message nack, will retry to publish message", "deliveryTag", deliveryTag)
-		case amqpErr := <-state.connErrCh:
-			log.Error("rabbitMQ connection failure", "err", amqpErr.Error())
+		case amqpErr, ok := <-state.connErrCh:
+			logAmqpFailure("rabbitMQ connection failure", amqpErr, ok)
 			rc.Reconnect()
-		case amqpErr := <-state.chanErr:
-			log.Error("rabbitMQ channel failure", "err", amqpErr.Error())
+		case amqpErr, ok := <-state.chanErr:
+			logAmqpFailure("rabbitMQ channel failure", amqpErr, ok)
 
 			// a connection failure is broadcast on the channel notification as well, so
 			// the recovery has to check what was actually lost
 			rc.recoverConnection()
 		}
 	}
+}
+
+func logAmqpFailure(message string, amqpErr *amqp.Error, okChanRead bool) {
+	if !okChanRead || amqpErr == nil {
+		log.Error(message, "err", "notification channel closed")
+		return
+	}
+
+	log.Error(message, "err", amqpErr.Error())
 }
 
 // ConnErrChan will return connection error channel

--- a/rabbitmq/rabbitClient_test.go
+++ b/rabbitmq/rabbitClient_test.go
@@ -396,15 +396,6 @@ func TestRabbitMqClient_ConcurrentOperations(t *testing.T) {
 	}
 }
 
-func TestRabbitMqClient_LogAmqpFailure(t *testing.T) {
-	t.Parallel()
-
-	require.NotPanics(t, func() {
-		logAmqpFailure("test", nil)
-		logAmqpFailure("test", &amqp.Error{Code: 501, Reason: "frame error"})
-	})
-}
-
 func TestRabbitMqClient_IsInterfaceNil(t *testing.T) {
 	t.Parallel()
 

--- a/rabbitmq/rabbitClient_test.go
+++ b/rabbitmq/rabbitClient_test.go
@@ -1,0 +1,416 @@
+package rabbitmq
+
+import (
+	"errors"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/streadway/amqp"
+	"github.com/stretchr/testify/require"
+)
+
+const testRetryInterval = time.Millisecond * 10
+
+var errDialFailed = errors.New("dial failed")
+
+// createTestClient creates a client which is not connected to any rabbitmq instance, with
+// a dial function which always fails and signals each attempt on the returned channel
+func createTestClient() (*rabbitMqClient, *int32, chan struct{}) {
+	numDialCalls := int32(0)
+	dialCalled := make(chan struct{}, 1)
+
+	rc := &rabbitMqClient{
+		url:           "amqp://guest:guest@localhost:5672/",
+		retryInterval: testRetryInterval,
+		closeChan:     make(chan struct{}),
+		dialFunc: func(url string) (*amqp.Connection, error) {
+			atomic.AddInt32(&numDialCalls, 1)
+
+			select {
+			case dialCalled <- struct{}{}:
+			default:
+			}
+
+			return nil, errDialFailed
+		},
+	}
+
+	return rc, &numDialCalls, dialCalled
+}
+
+func requireReturns(t *testing.T, description string, handler func()) {
+	done := make(chan struct{})
+	go func() {
+		handler()
+		close(done)
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(time.Second * 10):
+		require.Fail(t, description+" did not return")
+	}
+}
+
+func requireDialAttempted(t *testing.T, dialCalled chan struct{}) {
+	select {
+	case <-dialCalled:
+	case <-time.After(time.Second * 10):
+		require.Fail(t, "no dial attempt was made")
+	}
+}
+
+func TestNewRabbitMQClient(t *testing.T) {
+	t.Parallel()
+
+	t.Run("invalid url, should fail", func(t *testing.T) {
+		t.Parallel()
+
+		rc, err := NewRabbitMQClient("invalid url")
+		require.Error(t, err)
+		require.Nil(t, rc)
+	})
+}
+
+func TestRabbitMqClient_ExchangeDeclare(t *testing.T) {
+	t.Parallel()
+
+	t.Run("no channel available, should fail", func(t *testing.T) {
+		t.Parallel()
+
+		rc, _, _ := createTestClient()
+
+		err := rc.ExchangeDeclare("allevents", "fanout")
+		require.Equal(t, ErrClientClosed, err)
+		require.Empty(t, rc.exchanges)
+	})
+}
+
+func TestRabbitMqClient_SaveExchangeDeclaration(t *testing.T) {
+	t.Parallel()
+
+	t.Run("should save each exchange only once", func(t *testing.T) {
+		t.Parallel()
+
+		rc, _, _ := createTestClient()
+
+		rc.saveExchangeDeclaration("allevents", "fanout")
+		rc.saveExchangeDeclaration("revert", "fanout")
+		rc.saveExchangeDeclaration("allevents", "fanout")
+
+		expectedExchanges := []exchangeDeclaration{
+			{name: "allevents", kind: "fanout"},
+			{name: "revert", kind: "fanout"},
+		}
+		require.Equal(t, expectedExchanges, rc.exchanges)
+	})
+
+	t.Run("should update the exchange type", func(t *testing.T) {
+		t.Parallel()
+
+		rc, _, _ := createTestClient()
+
+		rc.saveExchangeDeclaration("allevents", "fanout")
+		rc.saveExchangeDeclaration("allevents", "direct")
+
+		expectedExchanges := []exchangeDeclaration{
+			{name: "allevents", kind: "direct"},
+		}
+		require.Equal(t, expectedExchanges, rc.exchanges)
+	})
+}
+
+func TestRabbitMqClient_RedeclareExchanges(t *testing.T) {
+	t.Parallel()
+
+	t.Run("no saved exchange, should not fail", func(t *testing.T) {
+		t.Parallel()
+
+		rc, _, _ := createTestClient()
+
+		err := rc.redeclareExchanges()
+		require.Nil(t, err)
+	})
+}
+
+func TestRabbitMqClient_Publish(t *testing.T) {
+	t.Parallel()
+
+	t.Run("closed client, should fail without trying to reconnect", func(t *testing.T) {
+		t.Parallel()
+
+		rc, numDialCalls, _ := createTestClient()
+		rc.Close()
+
+		err := rc.Publish("allevents", "", true, false, amqp.Publishing{})
+		require.Equal(t, ErrClientClosed, err)
+		require.Equal(t, int32(0), atomic.LoadInt32(numDialCalls))
+	})
+
+	t.Run("no channel available, should fail instead of panicking", func(t *testing.T) {
+		t.Parallel()
+
+		rc, _, _ := createTestClient()
+
+		err := rc.Publish("allevents", "", true, false, amqp.Publishing{})
+		require.Equal(t, ErrClientClosed, err)
+	})
+}
+
+func TestRabbitMqClient_Reconnect(t *testing.T) {
+	t.Parallel()
+
+	t.Run("should retry until the client is closed", func(t *testing.T) {
+		t.Parallel()
+
+		rc, numDialCalls, dialCalled := createTestClient()
+
+		done := make(chan struct{})
+		go func() {
+			rc.Reconnect()
+			close(done)
+		}()
+
+		requireDialAttempted(t, dialCalled)
+		rc.Close()
+
+		select {
+		case <-done:
+		case <-time.After(time.Second * 10):
+			require.Fail(t, "Reconnect did not stop after the client was closed")
+		}
+
+		require.True(t, atomic.LoadInt32(numDialCalls) >= 1)
+	})
+
+	t.Run("already closed client, should not dial", func(t *testing.T) {
+		t.Parallel()
+
+		rc, numDialCalls, _ := createTestClient()
+		rc.Close()
+
+		requireReturns(t, "Reconnect", rc.Reconnect)
+		require.Equal(t, int32(0), atomic.LoadInt32(numDialCalls))
+	})
+}
+
+func TestRabbitMqClient_ReopenChannel(t *testing.T) {
+	t.Parallel()
+
+	// a channel cannot be opened on a closed connection, so retrying to open the channel
+	// would loop forever. It has to fall back on re-establishing the connection.
+	t.Run("connection is down, should reconnect", func(t *testing.T) {
+		t.Parallel()
+
+		rc, _, dialCalled := createTestClient()
+
+		done := make(chan struct{})
+		go func() {
+			rc.ReopenChannel()
+			close(done)
+		}()
+
+		requireDialAttempted(t, dialCalled)
+		rc.Close()
+
+		select {
+		case <-done:
+		case <-time.After(time.Second * 10):
+			require.Fail(t, "ReopenChannel did not stop after the client was closed")
+		}
+	})
+
+	t.Run("already closed client, should not dial", func(t *testing.T) {
+		t.Parallel()
+
+		rc, numDialCalls, _ := createTestClient()
+		rc.Close()
+
+		requireReturns(t, "ReopenChannel", rc.ReopenChannel)
+		require.Equal(t, int32(0), atomic.LoadInt32(numDialCalls))
+	})
+}
+
+func TestRabbitMqClient_RecoverConnection(t *testing.T) {
+	t.Parallel()
+
+	t.Run("connection is down, should reconnect", func(t *testing.T) {
+		t.Parallel()
+
+		rc, _, dialCalled := createTestClient()
+
+		done := make(chan struct{})
+		go func() {
+			rc.recoverConnection()
+			close(done)
+		}()
+
+		requireDialAttempted(t, dialCalled)
+		rc.Close()
+
+		select {
+		case <-done:
+		case <-time.After(time.Second * 10):
+			require.Fail(t, "recoverConnection did not stop after the client was closed")
+		}
+	})
+}
+
+func TestRabbitMqClient_ConnectionIsDown(t *testing.T) {
+	t.Parallel()
+
+	rc, _, _ := createTestClient()
+	require.True(t, rc.connectionIsDown())
+}
+
+func TestRabbitMqClient_OpenChannel(t *testing.T) {
+	t.Parallel()
+
+	t.Run("no connection available, should fail", func(t *testing.T) {
+		t.Parallel()
+
+		rc, _, _ := createTestClient()
+
+		err := rc.tryOpenChannel()
+		require.Equal(t, ErrClientClosed, err)
+	})
+}
+
+func TestRabbitMqClient_Connect(t *testing.T) {
+	t.Parallel()
+
+	t.Run("dial fails, should return error", func(t *testing.T) {
+		t.Parallel()
+
+		rc, numDialCalls, _ := createTestClient()
+
+		err := rc.tryConnect()
+		require.Equal(t, errDialFailed, err)
+		require.Equal(t, int32(1), atomic.LoadInt32(numDialCalls))
+	})
+}
+
+func TestRabbitMqClient_WaitBeforeRetry(t *testing.T) {
+	t.Parallel()
+
+	t.Run("open client, should wait for the retry interval", func(t *testing.T) {
+		t.Parallel()
+
+		rc, _, _ := createTestClient()
+
+		startTime := time.Now()
+		require.False(t, rc.waitBeforeRetry())
+		require.True(t, time.Since(startTime) >= testRetryInterval)
+	})
+
+	t.Run("closed client, should not wait", func(t *testing.T) {
+		t.Parallel()
+
+		rc, _, _ := createTestClient()
+		rc.retryInterval = time.Minute
+		rc.Close()
+
+		startTime := time.Now()
+		require.True(t, rc.waitBeforeRetry())
+		require.True(t, time.Since(startTime) < time.Second)
+	})
+}
+
+func TestRabbitMqClient_Close(t *testing.T) {
+	t.Parallel()
+
+	t.Run("should be idempotent", func(t *testing.T) {
+		t.Parallel()
+
+		rc, _, _ := createTestClient()
+
+		require.False(t, rc.isClosed())
+
+		rc.Close()
+		rc.Close()
+
+		require.True(t, rc.isClosed())
+	})
+}
+
+func TestRabbitMqClient_ErrChannels(t *testing.T) {
+	t.Parallel()
+
+	rc, _, _ := createTestClient()
+
+	require.Nil(t, rc.ConnErrChan())
+	require.Nil(t, rc.CloseErrChan())
+
+	connErrCh := make(chan *amqp.Error, notifyChanBufferSize)
+	chanErr := make(chan *amqp.Error, notifyChanBufferSize)
+	rc.connErrCh = connErrCh
+	rc.chanErr = chanErr
+
+	require.Equal(t, connErrCh, rc.ConnErrChan())
+	require.Equal(t, chanErr, rc.CloseErrChan())
+}
+
+func TestRabbitMqClient_ConcurrentOperations(t *testing.T) {
+	t.Parallel()
+
+	rc, _, dialCalled := createTestClient()
+
+	numGoRoutines := 20
+	wg := sync.WaitGroup{}
+	wg.Add(numGoRoutines)
+
+	for i := 0; i < numGoRoutines; i++ {
+		go func(idx int) {
+			defer wg.Done()
+
+			switch idx % 5 {
+			case 0:
+				_ = rc.Publish("allevents", "", true, false, amqp.Publishing{})
+			case 1:
+				rc.Reconnect()
+			case 2:
+				rc.ReopenChannel()
+			case 3:
+				_ = rc.ExchangeDeclare("allevents", "fanout")
+			case 4:
+				_ = rc.ConnErrChan()
+			}
+		}(i)
+	}
+
+	requireDialAttempted(t, dialCalled)
+	rc.Close()
+
+	done := make(chan struct{})
+	go func() {
+		wg.Wait()
+		close(done)
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(time.Second * 10):
+		require.Fail(t, "not all operations returned after the client was closed")
+	}
+}
+
+func TestRabbitMqClient_LogAmqpFailure(t *testing.T) {
+	t.Parallel()
+
+	require.NotPanics(t, func() {
+		logAmqpFailure("test", nil)
+		logAmqpFailure("test", &amqp.Error{Code: 501, Reason: "frame error"})
+	})
+}
+
+func TestRabbitMqClient_IsInterfaceNil(t *testing.T) {
+	t.Parallel()
+
+	var rc *rabbitMqClient
+	require.True(t, rc.IsInterfaceNil())
+
+	rc, _, _ = createTestClient()
+	require.False(t, rc.IsInterfaceNil())
+}


### PR DESCRIPTION
Fixes and improvements on rabbitmq client reconnect on failure:

1. In the chanErr branch, check rc.conn.IsClosed() first and call Reconnect() rather than ReopenChannel(); and give ReopenChannel the same fallback internally so it can never spin on a dead connection.
2. Have Reconnect() close the old conn/channel, and add a redeclare hook so exchanges are re-created after every successful reconnect — the client needs the exchange list, or the publisher needs to be notified.
3. Use v, ok := <-rc.ackCh and treat !ok as "channel gone, retry", never as success. Same for the error channels.
4. Reset connErrCh on every recovery path, and buffer all notify channels with capacity 1.
5. Guard rc.conn/rc.ch reads with the mutex (or an atomic.Pointer), and add a closed flag checked by both retry loops so Close() can break them.